### PR TITLE
Make `from humanize import *` work

### DIFF
--- a/humanize/time.py
+++ b/humanize/time.py
@@ -8,7 +8,7 @@ import time
 from datetime import datetime, timedelta, date
 from .i18n import ngettext, gettext as _
 
-__all__ = ['naturaltime', 'naturalday', 'naturaldate']
+__all__ = ['naturaldelta', 'naturaltime', 'naturalday', 'naturaldate']
 
 def _now():
     return datetime.now()


### PR DESCRIPTION
This pull request fixes the following annoyance, by making `humanize.time` to export the missing `timedelta`:

```
>>> from humanize import *
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'naturaldelta'
```
