### PR TITLE
Added format parameter to naturalsize

### DIFF
--- a/humanize/filesize.py
+++ b/humanize/filesize.py
@@ -9,7 +9,8 @@ suffixes = {
     'gnu': "KMGTPEZY",
 }
 
-def naturalsize(value, binary=False, gnu=False):
+
+def naturalsize(value, binary=False, gnu=False, format='%.1f'):
     """Format a number of byteslike a human readable filesize (eg. 10 kB).  By
     default, decimal suffixes (kB, MB) are used.  Passing binary=true will use
     binary suffixes (KiB, MiB) are used and the base will be 2**10 instead of
@@ -30,10 +31,10 @@ def naturalsize(value, binary=False, gnu=False):
     for i,s in enumerate(suffix):
         unit = base ** (i+2)
         if bytes < unit and not gnu:
-            return '%.1f %s' % ((base * bytes / unit), s)
+            return (format + ' %s') % ((base * bytes / unit), s)
         elif bytes < unit and gnu:
-            return '%.1f%s' % ((base * bytes / unit), s)
+            return (format + '%s') % ((base * bytes / unit), s)
     if gnu:
-        return '%.1f%s' % ((base * bytes / unit), s)
-    return '%.1f %s' % ((base * bytes / unit), s)
+        return (format + '%s') % ((base * bytes / unit), s)
+    return (format + ' %s') % ((base * bytes / unit), s)
 

--- a/tests/filesize.py
+++ b/tests/filesize.py
@@ -11,9 +11,12 @@ class FilesizeTestCase(HumanizeTestCase):
         tests = (300, 3000, 3000000, 3000000000, 3000000000000, (300, True),
             (3000, True), (3000000, True), (300, False, True), (3000, False, True),
             (3000000, False, True), (1024, False, True), (10**26 * 30, False, True),
-            (10**26 * 30, True), 10**26 * 30)
+            (10**26 * 30, True), 10**26 * 30,
+            (3141592, False, False, '%.2f'), (3000, False, True, '%.3f'),
+            (3000000000, False, True, '%.0f'), (10**26 * 30, True, False, '%.3f'),)
         results = ('300 Bytes', '3.0 kB', '3.0 MB', '3.0 GB', '3.0 TB',
             '300 Bytes', '2.9 KiB', '2.9 MiB', '300B', '2.9K', '2.9M', '1.0K', '2481.5Y',
-            '2481.5 YiB', '3000.0 YB')
+            '2481.5 YiB', '3000.0 YB',
+            '3.14 MB', '2.930K', '3G', '2481.542 YiB')
         self.assertManyResults(filesize.naturalsize, tests, results)
 


### PR DESCRIPTION
This adds a formatting option so `naturalsize` can return values like `3.14 MB` or `3M` if desired. Default behavior is unchanged.  

I based this on code already in `humanize.intword`. Formatting only applies to the number, not the filesize suffix. 

Several additional tests were added to `FileSizeTestCase`; all tests passed under Python 3.3.2 and 2.7.5
