### PR TITLE
Fix setup issue on windows with py3.3 where wrong file encoding was used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@
 
 from setuptools import setup, find_packages
 import sys, os
+import io
 
 version = '0.5'
 
@@ -15,7 +16,7 @@ setup(
     name='humanize',
     version=version,
     description="python humanize utilities",
-    long_description=open('README.rst', encoding="utf-8").read(),
+    long_description=io.open('README.rst', encoding="utf-8").read(),
     # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
This came up when trying to install the pypi package on windows with python 3.3.

```
 Traceback (most recent call last):
   File "<string>", line 17, in <module>
   File "C:\...\env\build\humanize\setup.py", line 18, in <module>
     long_description=open('README.rst').read(),
   File "C:\Python33\lib\encodings\cp1252.py", line 23, in decode
     return codecs.charmap_decode(input,self.errors,decoding_table)[0]
 UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 2017: character maps to  <undefined>
 Complete output from command python setup.py egg_info:
 Traceback (most recent call last):
File "<string>", line 17, in <module>
File "C:\...\env\build\humanize\setup.py", line 18, in <module>
  long_description=open('README.rst').read(),
File "C:\Python33\lib\encodings\cp1252.py", line 23, in decode
  return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 2017: character maps to <undefined>
```
