### PR TITLE
adds the translation file for brazilian portuguese

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ humanize
 This modest package contains various common humanization utilities, like turning
 a number into a fuzzy human readable duration ('3 minutes ago') or into a human
 readable size or throughput.  It works with python 2.7 and 3.3 and is localized
-to Russian, French, and Korean.
+to Russian, French, Brazilian Portuguese and Korean.
 
 usage
 -----
@@ -82,9 +82,9 @@ How to change locale in runtime ::
 You can pass additional parameter *path* to :func:`activate` to specify a path to
 search locales in. ::
 
-    >>> humanize.i18n.activate('pt_BR')
+    >>> humanize.i18n.activate('cs_CZ')
     IOError: [Errno 2] No translation file found for domain: 'humanize'
-    >>> humanize.i18n.activate('pt_BR', path='path/to/my/portuguese/translation/')
+    >>> humanize.i18n.activate('cs_CZ', path='path/to/my/czech/translation/')
     <gettext.GNUTranslations instance ...>
 
 How to add new phrases to existing locale files ::

--- a/humanize/locale/pt_BR/LC_MESSAGES/humanize.po
+++ b/humanize/locale/pt_BR/LC_MESSAGES/humanize.po
@@ -1,0 +1,229 @@
+# Translations template for PROJECT.
+# Copyright (C) 2014 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2014.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2014-03-23 01:08-0300\n"
+"PO-Revision-Date: 2014-03-23 01:12-0300\n"
+"Last-Translator: Caio Begotti <caio1982@gmail.com>\n"
+"Language-Team: pt_BR <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 1.3\n"
+
+#: humanize/number.py:20
+msgid "th"
+msgstr ".º"
+
+#: humanize/number.py:20
+msgid "st"
+msgstr ".º"
+
+#: humanize/number.py:20
+msgid "nd"
+msgstr ".º"
+
+#: humanize/number.py:20
+msgid "rd"
+msgstr ".º"
+
+#: humanize/number.py:46
+msgid "million"
+msgstr "milhão"
+
+#: humanize/number.py:46
+msgid "billion"
+msgstr "bilhão"
+
+#: humanize/number.py:46
+msgid "trillion"
+msgstr "trilhão"
+
+#: humanize/number.py:46
+msgid "quadrillion"
+msgstr "quatrilhão"
+
+#: humanize/number.py:47
+msgid "quintillion"
+msgstr "quintilhão"
+
+#: humanize/number.py:47
+msgid "sextillion"
+msgstr "sextilhão"
+
+#: humanize/number.py:47
+msgid "septillion"
+msgstr "septilhão"
+
+#: humanize/number.py:48
+msgid "octillion"
+msgstr "octilhão"
+
+#: humanize/number.py:48
+msgid "nonillion"
+msgstr "nonilhão"
+
+#: humanize/number.py:48
+msgid "decillion"
+msgstr "decilhão"
+
+#: humanize/number.py:48
+msgid "googol"
+msgstr "googol"
+
+#: humanize/number.py:82
+msgid "one"
+msgstr "um"
+
+#: humanize/number.py:82
+msgid "two"
+msgstr "dois"
+
+#: humanize/number.py:82
+msgid "three"
+msgstr "três"
+
+#: humanize/number.py:82
+msgid "four"
+msgstr "quatro"
+
+#: humanize/number.py:82
+msgid "five"
+msgstr "cinco"
+
+#: humanize/number.py:82
+msgid "six"
+msgstr "seis"
+
+#: humanize/number.py:83
+msgid "seven"
+msgstr "sete"
+
+#: humanize/number.py:83
+msgid "eight"
+msgstr "oito"
+
+#: humanize/number.py:83
+msgid "nine"
+msgstr "nove"
+
+#: humanize/time.py:64 humanize/time.py:126
+msgid "a moment"
+msgstr "um momento"
+
+#: humanize/time.py:66
+msgid "a second"
+msgstr "um segundo"
+
+#: humanize/time.py:68
+#, python-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d segundo"
+msgstr[1] "%d segundos"
+
+#: humanize/time.py:70
+msgid "a minute"
+msgstr "um minuto"
+
+#: humanize/time.py:73
+#, python-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minuto"
+msgstr[1] "%d minutos"
+
+#: humanize/time.py:75
+msgid "an hour"
+msgstr "uma hora"
+
+#: humanize/time.py:78
+#, python-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d hora"
+msgstr[1] "%d horas"
+
+#: humanize/time.py:81
+msgid "a day"
+msgstr "um dia"
+
+#: humanize/time.py:83 humanize/time.py:86
+#, python-format
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] "%d dia"
+msgstr[1] "%d dias"
+
+#: humanize/time.py:88
+msgid "a month"
+msgstr "um mês"
+
+#: humanize/time.py:90
+#, python-format
+msgid "%d month"
+msgid_plural "%d months"
+msgstr[0] "%d mês"
+msgstr[1] "%d meses"
+
+#: humanize/time.py:93
+msgid "a year"
+msgstr "um ano"
+
+#: humanize/time.py:95 humanize/time.py:103
+#, python-format
+msgid "1 year, %d day"
+msgid_plural "1 year, %d days"
+msgstr[0] "1 ano, %d dia"
+msgstr[1] "1 ano, %d dias"
+
+#: humanize/time.py:98
+msgid "1 year, 1 month"
+msgstr "1 ano, 1 mês"
+
+#: humanize/time.py:100
+#, python-format
+msgid "1 year, %d month"
+msgid_plural "1 year, %d months"
+msgstr[0] "1 ano, %d mês"
+msgstr[1] "1 ano, %d meses"
+
+#: humanize/time.py:105
+#, python-format
+msgid "%d year"
+msgid_plural "%d years"
+msgstr[0] "%d ano"
+msgstr[1] "%d anos"
+
+#: humanize/time.py:123
+#, python-format
+msgid "%s from now"
+msgstr "%s a partir de agora"
+
+#: humanize/time.py:123
+#, python-format
+msgid "%s ago"
+msgstr "%s atrás"
+
+#: humanize/time.py:127
+msgid "now"
+msgstr "agora"
+
+#: humanize/time.py:145
+msgid "today"
+msgstr "hoje"
+
+#: humanize/time.py:147
+msgid "tomorrow"
+msgstr "amanhã"
+
+#: humanize/time.py:149
+msgid "yesterday"
+msgstr "ontem"
+


### PR DESCRIPTION
Hello there! This is funny, because I was looking for a Python module that does precisely the reverse operation that your code does, which means I'm still looking for a solution to "dehumanize" numbers, but then I saw the missing pt_BR translation message in your README and thought that I should fix that :-)

Slightly offtopic but still linguistics-wise: the translation is not 100% accurate as we have different genders for ordinal numbers in portuguese (not particular to the brazilian dialect, it's part of the language itself) but often we just consider them as masculine nouns, hence the ".º" around. Also, besides the 1st, 2nd and 3rd equivalents we have different names for all the other numbers up to 9th, and yet another suffix "-ésimo" for ordinals ending with zero such as 20th, 30th, 40th etc as we don't have anything like "th" in the written form.
