### PR TITLE
Fixing timezone-aware datetime handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     test_suite="tests",
     tests_require=['mock'],
     install_requires=[
-      # -*- Extra requirements: -*-
+      'pytz'
     ],
     entry_points="""
     # -*- Entry points: -*-

--- a/tests/time.py
+++ b/tests/time.py
@@ -4,6 +4,7 @@
 """Tests for time humanizing."""
 
 from mock import patch
+from pytz import utc
 
 from humanize import time
 from datetime import date, datetime, timedelta
@@ -11,6 +12,8 @@ from .base import HumanizeTestCase
 
 today = date.today()
 one_day = timedelta(days=1)
+today_tzaware = utc.localize(datetime.utcnow()).date()
+
 
 class fakedate(object):
     def __init__(self, year, month, day):
@@ -36,7 +39,7 @@ class TimeTestCase(HumanizeTestCase):
     """Tests for the public interface of humanize.time"""
 
     def test_naturaldelta_nomonths(self):
-        now = datetime.now()
+
         test_list = [
             timedelta(days=7),
             timedelta(days=31),
@@ -49,10 +52,20 @@ class TimeTestCase(HumanizeTestCase):
             '230 days',
             '1 year, 35 days',
         ]
+
+
+        now = datetime.now()
         with patch('humanize.time._now') as mocked:
             mocked.return_value = now
             nd_nomonths = lambda d: time.naturaldelta(d, months=False)
             self.assertManyResults(nd_nomonths, test_list, result_list)
+
+        now = utc.localize(datetime.utcnow())
+        with patch('humanize.time._now') as mocked:
+            mocked.return_value = now
+            nd_nomonths = lambda d: time.naturaldelta(d, months=False)
+            self.assertManyResults(nd_nomonths, test_list, result_list)
+
 
     def test_naturaldelta(self):
         now = datetime.now()
@@ -283,6 +296,262 @@ class TimeTestCase(HumanizeTestCase):
             someday_result = 'Sep 05'
 
         test_list = (today, tomorrow, yesterday, someday, date(1982, 6, 27))
+        result_list = ('today', 'tomorrow', 'yesterday', someday_result, 'Jun 27 1982')
+        self.assertManyResults(time.naturaldate, test_list, result_list)
+
+class TimeTestCaseTimezoneAware(HumanizeTestCase):
+    """Tests for the public interface of humanize.time, working entirely with tzaware dates"""
+
+    def test_naturaldelta_nomonths(self):
+        now = utc.localize(datetime.utcnow())
+        test_list = [
+            timedelta(days=7),
+            timedelta(days=31),
+            timedelta(days=230),
+            timedelta(days=400),
+        ]
+        result_list = [
+            '7 days',
+            '31 days',
+            '230 days',
+            '1 year, 35 days',
+        ]
+
+        with patch('humanize.time._now') as mocked:
+            mocked.return_value = now
+            nd_nomonths = lambda d: time.naturaldelta(d, months=False)
+            self.assertManyResults(nd_nomonths, test_list, result_list)
+
+
+    def test_naturaldelta(self):
+        now = utc.localize(datetime.utcnow())
+        test_list = [
+            0,
+            1,
+            30,
+            timedelta(minutes=1, seconds=30),
+            timedelta(minutes=2),
+            timedelta(hours=1, minutes=30, seconds=30),
+            timedelta(hours=23, minutes=50, seconds=50),
+            timedelta(days=1),
+            timedelta(days=500),
+            timedelta(days=365*2 + 35),
+            timedelta(seconds=1),
+            timedelta(seconds=30),
+            timedelta(minutes=1, seconds=30),
+            timedelta(minutes=2),
+            timedelta(hours=1, minutes=30, seconds=30),
+            timedelta(hours=23, minutes=50, seconds=50),
+            timedelta(days=1),
+            timedelta(days=500),
+            timedelta(days=365*2 + 35),
+            # regression tests for bugs in post-release humanize
+            timedelta(days=10000),
+            timedelta(days=365+35),
+            30,
+            timedelta(days=365*2 + 65),
+            timedelta(days=365 + 4),
+            timedelta(days=35),
+            timedelta(days=65),
+            timedelta(days=9),
+            timedelta(days=365),
+            "NaN",
+        ]
+        result_list = [
+            'a moment',
+            'a second',
+            '30 seconds',
+            'a minute',
+            '2 minutes',
+            'an hour',
+            '23 hours',
+            'a day',
+            '1 year, 4 months',
+            '2 years',
+            'a second',
+            '30 seconds',
+            'a minute',
+            '2 minutes',
+            'an hour',
+            '23 hours',
+            'a day',
+            '1 year, 4 months',
+            '2 years',
+            '27 years',
+            '1 year, 1 month',
+            '30 seconds',
+            '2 years',
+            '1 year, 4 days',
+            'a month',
+            '2 months',
+            '9 days',
+            'a year',
+            "NaN",
+        ]
+        with patch('humanize.time._now') as mocked:
+            mocked.return_value = now
+            self.assertManyResults(time.naturaldelta, test_list, result_list)
+
+    def test_naturaltime(self):
+        now = utc.localize(datetime.utcnow())
+        test_list = [
+            now,
+            now - timedelta(seconds=1),
+            now - timedelta(seconds=30),
+            now - timedelta(minutes=1, seconds=30),
+            now - timedelta(minutes=2),
+            now - timedelta(hours=1, minutes=30, seconds=30),
+            now - timedelta(hours=23, minutes=50, seconds=50),
+            now - timedelta(days=1),
+            now - timedelta(days=500),
+            now - timedelta(days=365*2 + 35),
+            now + timedelta(seconds=1),
+            now + timedelta(seconds=30),
+            now + timedelta(minutes=1, seconds=30),
+            now + timedelta(minutes=2),
+            now + timedelta(hours=1, minutes=30, seconds=30),
+            now + timedelta(hours=23, minutes=50, seconds=50),
+            now + timedelta(days=1),
+            now + timedelta(days=500),
+            now + timedelta(days=365*2 + 35),
+            # regression tests for bugs in post-release humanize
+            now + timedelta(days=10000),
+            now - timedelta(days=365+35),
+            30,
+            now - timedelta(days=365*2 + 65),
+            now - timedelta(days=365 + 4),
+            "NaN",
+        ]
+        result_list = [
+            'now',
+            'a second ago',
+            '30 seconds ago',
+            'a minute ago',
+            '2 minutes ago',
+            'an hour ago',
+            '23 hours ago',
+            'a day ago',
+            '1 year, 4 months ago',
+            '2 years ago',
+            'a second from now',
+            '30 seconds from now',
+            'a minute from now',
+            '2 minutes from now',
+            'an hour from now',
+            '23 hours from now',
+            'a day from now',
+            '1 year, 4 months from now',
+            '2 years from now',
+            '27 years from now',
+            '1 year, 1 month ago',
+            '30 seconds ago',
+            '2 years ago',
+            '1 year, 4 days ago',
+            "NaN",
+        ]
+        with patch('humanize.time._now') as mocked:
+            mocked.return_value = now
+            self.assertManyResults(time.naturaltime, test_list, result_list)
+
+    def test_naturaltime_nomonths(self):
+        now = utc.localize(datetime.utcnow())
+        test_list = [
+            now,
+            now - timedelta(seconds=1),
+            now - timedelta(seconds=30),
+            now - timedelta(minutes=1, seconds=30),
+            now - timedelta(minutes=2),
+            now - timedelta(hours=1, minutes=30, seconds=30),
+            now - timedelta(hours=23, minutes=50, seconds=50),
+            now - timedelta(days=1),
+            now - timedelta(days=17),
+            now - timedelta(days=47),
+            now - timedelta(days=500),
+            now - timedelta(days=365*2 + 35),
+            now + timedelta(seconds=1),
+            now + timedelta(seconds=30),
+            now + timedelta(minutes=1, seconds=30),
+            now + timedelta(minutes=2),
+            now + timedelta(hours=1, minutes=30, seconds=30),
+            now + timedelta(hours=23, minutes=50, seconds=50),
+            now + timedelta(days=1),
+            now + timedelta(days=500),
+            now + timedelta(days=365*2 + 35),
+            # regression tests for bugs in post-release humanize
+            now + timedelta(days=10000),
+            now - timedelta(days=365+35),
+            30,
+            now - timedelta(days=365*2 + 65),
+            now - timedelta(days=365 + 4),
+            "NaN",
+        ]
+        result_list = [
+            'now',
+            'a second ago',
+            '30 seconds ago',
+            'a minute ago',
+            '2 minutes ago',
+            'an hour ago',
+            '23 hours ago',
+            'a day ago',
+            '17 days ago',
+            '47 days ago',
+            '1 year, 135 days ago',
+            '2 years ago',
+            'a second from now',
+            '30 seconds from now',
+            'a minute from now',
+            '2 minutes from now',
+            'an hour from now',
+            '23 hours from now',
+            'a day from now',
+            '1 year, 135 days from now',
+            '2 years from now',
+            '27 years from now',
+            '1 year, 35 days ago',
+            '30 seconds ago',
+            '2 years ago',
+            '1 year, 4 days ago',
+            "NaN",
+        ]
+        with patch('humanize.time._now') as mocked:
+            mocked.return_value = now
+            nt_nomonths = lambda d: time.naturaltime(d, months=False)
+            self.assertManyResults(nt_nomonths, test_list, result_list)
+
+    def test_naturalday(self):
+        tomorrow = today_tzaware + one_day
+        yesterday = today_tzaware - one_day
+        if today_tzaware.month != 3:
+            someday = date(today_tzaware.year, 3, 5)
+            someday_result = 'Mar 05'
+        else:
+            someday = date(today_tzaware.year, 9, 5)
+            someday_result = 'Sep 05'
+        valerrtest = fakedate(290149024, 2, 2)
+        overflowtest = fakedate(120390192341, 2, 2)
+        test_list = (today_tzaware, tomorrow, yesterday, someday, '02/26/1984',
+            (date(1982, 6, 27), '%Y.%M.%D'), None, "Not a date at all.",
+            valerrtest, overflowtest
+        )
+        result_list = ('today', 'tomorrow', 'yesterday', someday_result, '02/26/1984',
+            date(1982, 6, 27).strftime('%Y.%M.%D'), None, "Not a date at all.",
+            valerrtest, overflowtest
+        )
+        self.assertManyResults(time.naturalday, test_list, result_list)
+
+    def test_naturaldate(self):
+        tomorrow = today_tzaware + one_day
+        yesterday = today_tzaware - one_day
+
+        if today_tzaware.month != 3:
+            someday = date(today_tzaware.year, 3, 5)
+            someday_result = 'Mar 05'
+        else:
+            someday = date(today_tzaware.year, 9, 5)
+            someday_result = 'Sep 05'
+
+        test_list = (today_tzaware, tomorrow, yesterday, someday, date(1982, 6, 27))
         result_list = ('today', 'tomorrow', 'yesterday', someday_result, 'Jun 27 1982')
         self.assertManyResults(time.naturaldate, test_list, result_list)
 

--- a/tests/time.py
+++ b/tests/time.py
@@ -19,10 +19,11 @@ class fakedate(object):
     def __init__(self, year, month, day):
         self.year, self.month, self.day = year, month, day
 
+
 class TimeUtilitiesTestCase(HumanizeTestCase):
     """These are not considered "public" interfaces, but require tests anyway."""
     def test_date_and_delta(self):
-        now = datetime.now()
+        now = utc.localize(datetime.utcnow())
         td = timedelta
         int_tests = (3, 29, 86399, 86400, 86401*30)
         date_tests = [now - td(seconds=x) for x in int_tests]
@@ -34,6 +35,7 @@ class TimeUtilitiesTestCase(HumanizeTestCase):
                 self.assertEqualDatetime(dt, result[0])
                 self.assertEqualTimedelta(d, result[1])
         self.assertEqual(time.date_and_delta("NaN"), (None, "NaN"))
+
 
 class TimeTestCase(HumanizeTestCase):
     """Tests for the public interface of humanize.time"""
@@ -54,12 +56,6 @@ class TimeTestCase(HumanizeTestCase):
         ]
 
 
-        now = datetime.now()
-        with patch('humanize.time._now') as mocked:
-            mocked.return_value = now
-            nd_nomonths = lambda d: time.naturaldelta(d, months=False)
-            self.assertManyResults(nd_nomonths, test_list, result_list)
-
         now = utc.localize(datetime.utcnow())
         with patch('humanize.time._now') as mocked:
             mocked.return_value = now
@@ -68,7 +64,7 @@ class TimeTestCase(HumanizeTestCase):
 
 
     def test_naturaldelta(self):
-        now = datetime.now()
+        now = utc.localize(datetime.utcnow())
         test_list = [
             0,
             1,
@@ -134,10 +130,12 @@ class TimeTestCase(HumanizeTestCase):
         ]
         with patch('humanize.time._now') as mocked:
             mocked.return_value = now
+
+
             self.assertManyResults(time.naturaldelta, test_list, result_list)
 
     def test_naturaltime(self):
-        now = datetime.now()
+        now = utc.localize(datetime.utcnow())
         test_list = [
             now,
             now - timedelta(seconds=1),
@@ -198,7 +196,7 @@ class TimeTestCase(HumanizeTestCase):
             self.assertManyResults(time.naturaltime, test_list, result_list)
 
     def test_naturaltime_nomonths(self):
-        now = datetime.now()
+        now = utc.localize(datetime.utcnow())
         test_list = [
             now,
             now - timedelta(seconds=1),
@@ -554,4 +552,3 @@ class TimeTestCaseTimezoneAware(HumanizeTestCase):
         test_list = (today_tzaware, tomorrow, yesterday, someday, date(1982, 6, 27))
         result_list = ('today', 'tomorrow', 'yesterday', someday_result, 'Jun 27 1982')
         self.assertManyResults(time.naturaldate, test_list, result_list)
-


### PR DESCRIPTION
Previously, passing the current time in UTC will generate incorrect deltas. For example, if I pass a recent time in UTC, it'll tell you '7 hours from now' when the answer really is '30 minutes ago'.

I've changed it to look for tz awareness in the date string and if it finds it, it will calculate the delta using the current date in UTC.

Added tests around the change - mostly just copypasting what was there, except with UTC dates. Let me know if you want any changes there. Thanks. 