### PR TITLE
Add scientific notation to string support

### DIFF
--- a/humanize/number.py
+++ b/humanize/number.py
@@ -7,7 +7,6 @@ import re
 from fractions import Fraction
 from .import compat
 from .i18n import gettext as _, gettext_noop as N_, pgettext as P_
-import decimal
 
 
 def ordinal(value):

--- a/humanize/number.py
+++ b/humanize/number.py
@@ -124,13 +124,15 @@ def fractional(value):
     else:
         return '%.0f %.0f/%.0f' % (wholeNumber, numerator, denominator)
 
-def scientific(value):
+def scientific(value,precision=2):
     '''
     Return number in string scientific notation z.wq x 10ⁿ
     Examples:
         float(0.3) will return '3.00 x 10⁻¹'
         int(500) will return '5.00 x 10²'
     This will always return a string.
+
+    :param precision int : Number of decimal for first par number
     '''
     exponents = {
         "0": "⁰",
@@ -153,7 +155,8 @@ def scientific(value):
             negative = True
         if isinstance(value, str):
             value = float(value)
-        n = '{:.2e}'.format(value)
+        fmt = '{:.%se}' % str(int(precision))
+        n = fmt.format(value)
     except (ValueError, TypeError):
         return value
     part1, part2 = n.split("e")

--- a/humanize/number.py
+++ b/humanize/number.py
@@ -7,6 +7,7 @@ import re
 from fractions import Fraction
 from .import compat
 from .i18n import gettext as _, gettext_noop as N_, pgettext as P_
+import decimal
 
 
 def ordinal(value):
@@ -123,3 +124,48 @@ def fractional(value):
         return '%.0f/%.0f' % (numerator, denominator)
     else:
         return '%.0f %.0f/%.0f' % (wholeNumber, numerator, denominator)
+
+def scientific(value):
+    '''
+    Return number in string scientific notation z.wq x 10ⁿ
+    Examples:
+        float(0.3) will return '3.00 x 10⁻¹'
+        int(500) will return '5.00 x 10²'
+    This will always return a string.
+    '''
+    exposants = {
+        "0": "⁰",
+        "1": "¹",
+        "2": "²",
+        "3": "³",
+        "4": "⁴",
+        "5": "⁵",
+        "6": "⁶",
+        "7": "⁷",
+        "8": "⁸",
+        "9": "⁹",
+        "+": "⁺",
+        "-": "⁻",
+    }
+    negative = False
+    try:
+        if "-" in str(value):
+            value = str(value).replace("-", "")
+            negative = True
+        if isinstance(value, str):
+            value = float(value)
+        n = '{:.2e}'.format(value)
+    except (ValueError, TypeError):
+        return value
+    part1, part2 = n.split("e")
+    if "-0" in part2 :
+        part2 = part2.replace("-0","-")
+    if "+0" in part2:
+        part2 = part2.replace("+0", "")
+    new_part2 = []
+    if negative:
+        new_part2.append(exposants["-"])
+    for char in part2:
+        new_part2.append(exposants[char])
+    final_str = part1 + " x 10" + "".join(new_part2)
+    return final_str

--- a/humanize/number.py
+++ b/humanize/number.py
@@ -132,7 +132,7 @@ def scientific(value):
         int(500) will return '5.00 x 10²'
     This will always return a string.
     '''
-    exposants = {
+    exponents = {
         "0": "⁰",
         "1": "¹",
         "2": "²",
@@ -163,8 +163,8 @@ def scientific(value):
         part2 = part2.replace("+0", "")
     new_part2 = []
     if negative:
-        new_part2.append(exposants["-"])
+        new_part2.append(exponents["-"])
     for char in part2:
-        new_part2.append(exposants[char])
+        new_part2.append(exponents[char])
     final_str = part1 + " x 10" + "".join(new_part2)
     return final_str

--- a/tests/number.py
+++ b/tests/number.py
@@ -51,3 +51,7 @@ class NumberTestCase(HumanizeTestCase):
         test_list = (1000, -1000, 5.5, 5781651000, "1000", "99", float(0.3),'foo', None)
         result_list = ('1.00 x 10³', '1.00 x 10⁻³', '5.50 x 10⁰', '5.78 x 10⁹', '1.00 x 10³', '9.90 x 10¹','3.00 x 10⁻¹', 'foo', None)
         self.assertManyResults(number.scientific, test_list, result_list)
+        self.assertEqual(number.scientific(1000,precision=1), '1.0 x 10³')
+        self.assertEqual(number.scientific(float(0.3),precision=1), '3.0 x 10⁻¹')
+        self.assertEqual(number.scientific(1000,precision=0), '1 x 10³')
+        self.assertEqual(number.scientific(float(0.3),precision=0), '3 x 10⁻¹')

--- a/tests/number.py
+++ b/tests/number.py
@@ -46,3 +46,8 @@ class NumberTestCase(HumanizeTestCase):
         test_list = (1, 2.0, (4.0/3.0), (5.0/6.0), '7', '8.9', 'ten', None)
         result_list = ('1', '2', '1 1/3', '5/6', '7',  '8 9/10', 'ten', None)
         self.assertManyResults(number.fractional, test_list, result_list)
+
+    def test_scientific(self):
+        test_list = (1000, -1000, 5.5, 5781651000, "1000", "99", float(0.3),'foo', None)
+        result_list = ('1.00 x 10³', '1.00 x 10⁻³', '5.50 x 10⁰', '5.78 x 10⁹', '1.00 x 10³', '9.90 x 10¹','3.00 x 10⁻¹', 'foo', None)
+        self.assertManyResults(number.scientific, test_list, result_list)


### PR DESCRIPTION
Hello,

Add scientific notation conversion to human string.

Example : `float(0.3)` will return `3.00 x 10⁻¹`