### PR TITLE
Add tests to MANIFEST.in to include them in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.rst
 include LICENCE
 recursive-include humanize/locale *
+recursive-include tests *.py


### PR DESCRIPTION
I'm an OpenBSD porter and we like to be able to run regression tests on our ports.

This change to MANIFEST.in will include them in the next version's tarball on PyPI