### PR TITLE
Use built-in mock from unittest when available (Python 3.4+)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     test_suite="tests",
-    tests_require=['mock'],
+    tests_require=['mock;python_version<"3.4"'],
     install_requires=[
       # -*- Extra requirements: -*-
     ],

--- a/tests/time.py
+++ b/tests/time.py
@@ -3,7 +3,10 @@
 
 """Tests for time humanizing."""
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except (ImportError, AttributeError):
+    from mock import patch
 
 from humanize import time
 from datetime import date, datetime, timedelta


### PR DESCRIPTION
mock is a backport for versions of python < 3.4

Let's use the mock that comes with Python for recent versions of Python 3.x