### PR TITLE
Fix DeprecationWarnings due to invalid escape sequence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-tags
-*.py[co]
-*.sw[po]
 *.egg-info*
 *.pot
-docs/_build*
+*.py[co]
+*.sw[po]
+.eggs
 build
 dist
+docs/_build*
+tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: python
 python:
  - 2.7
- - 3.3
+ - 3.5
+ - 3.6
+ - 3.7
+ - 3.8
  - "pypy"
 
 script: python setup.py test

--- a/humanize/number.py
+++ b/humanize/number.py
@@ -45,7 +45,7 @@ def intcomma(value):
     except (TypeError, ValueError):
         return value
     orig = str(value)
-    new = re.sub("^(-?\d+)(\d{3})", '\g<1>,\g<2>', orig)
+    new = re.sub(r"^(-?\d+)(\d{3})", r"\g<1>,\g<2>", orig)
     if orig == new:
         return new
     else:


### PR DESCRIPTION
Fixes https://github.com/jmoiron/humanize/issues/82

> Also, please note that any invalid escape sequences in Python’s usage of the backslash in string literals now generate a DeprecationWarning and in the future this will become a SyntaxError. This behaviour will happen even if it is a valid escape sequence for a regular expression.
>
> The solution is to use Python’s raw string notation for regular expression patterns; backslashes are not handled in any special way in a string literal prefixed with 'r'. So r"\n" is a two-character string containing '\' and 'n', while "\n" is a one-character string containing a newline. Usually patterns will be expressed in Python code using this raw string notation.

https://docs.python.org/3/library/re.html

---

Also, EOL Python 3.3 is [no longer available on Travis CI](https://travis-ci.com/hugovk/humanize/jobs/280093725), so I removed it and added newer 3.5-3.8 to make sure 3.x passes tests on the CI.

And it looks like Travis needs re-activating for this repo, here's this PR passing on my fork:

https://travis-ci.com/hugovk/humanize/builds/146074018


