### PR TITLE
Improve test coverage to 100%

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ setup(
     version=version,
     description="python humanize utilities",
     long_description=io.open('README.rst', 'r', encoding="UTF-8").read(),
-    extras_require = {
-        "tests": ["pytest", "pytest-cov"],
+    extras_require={
+        "tests": ["freezegun", "pytest", "pytest-cov"],
         "tests:python_version < '3.4'": ["mock"],
     },
     # Get strings from https://pypi.org/pypi?%3Aaction=list_classifiers

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+import datetime as dt
+
+import humanize
+
+
+def test_i18n():
+    three_seconds = dt.timedelta(seconds=3)
+
+    assert humanize.naturaltime(three_seconds) == "3 seconds ago"
+
+    humanize.i18n.activate("ru_RU")
+    assert humanize.naturaltime(three_seconds) == "3 секунды назад"
+
+    humanize.i18n.deactivate()
+    assert humanize.naturaltime(three_seconds) == "3 seconds ago"

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -13,7 +13,7 @@ from datetime import date, datetime, timedelta
 from freezegun import freeze_time
 from .base import HumanizeTestCase
 
-one_day = timedelta(days=1)
+ONE_DAY = timedelta(days=1)
 
 
 class fakedate(object):
@@ -21,12 +21,17 @@ class fakedate(object):
         self.year, self.month, self.day = year, month, day
 
 
+VALUE_ERROR_TEST = fakedate(290149024, 2, 2)
+OVERFLOW_ERROR_TEST = fakedate(120390192341, 2, 2)
+
+
 class TimeUtilitiesTestCase(HumanizeTestCase):
     """These are not considered "public" interfaces, but require tests anyway."""
+
     def test_date_and_delta(self):
         now = datetime.now()
         td = timedelta
-        int_tests = (3, 29, 86399, 86400, 86401*30)
+        int_tests = (3, 29, 86399, 86400, 86401 * 30)
         date_tests = [now - td(seconds=x) for x in int_tests]
         td_tests = [td(seconds=x) for x in int_tests]
         results = [(now - td(seconds=x), td(seconds=x)) for x in int_tests]
@@ -72,7 +77,7 @@ class TimeTestCase(HumanizeTestCase):
             timedelta(hours=23, minutes=50, seconds=50),
             timedelta(days=1),
             timedelta(days=500),
-            timedelta(days=365*2 + 35),
+            timedelta(days=365 * 2 + 35),
             timedelta(seconds=1),
             timedelta(seconds=30),
             timedelta(minutes=1, seconds=30),
@@ -81,12 +86,12 @@ class TimeTestCase(HumanizeTestCase):
             timedelta(hours=23, minutes=50, seconds=50),
             timedelta(days=1),
             timedelta(days=500),
-            timedelta(days=365*2 + 35),
+            timedelta(days=365 * 2 + 35),
             # regression tests for bugs in post-release humanize
             timedelta(days=10000),
-            timedelta(days=365+35),
+            timedelta(days=365 + 35),
             30,
-            timedelta(days=365*2 + 65),
+            timedelta(days=365 * 2 + 65),
             timedelta(days=365 + 4),
             timedelta(days=35),
             timedelta(days=65),
@@ -141,7 +146,7 @@ class TimeTestCase(HumanizeTestCase):
             now - timedelta(hours=23, minutes=50, seconds=50),
             now - timedelta(days=1),
             now - timedelta(days=500),
-            now - timedelta(days=365*2 + 35),
+            now - timedelta(days=365 * 2 + 35),
             now + timedelta(seconds=1),
             now + timedelta(seconds=30),
             now + timedelta(minutes=1, seconds=30),
@@ -150,12 +155,12 @@ class TimeTestCase(HumanizeTestCase):
             now + timedelta(hours=23, minutes=50, seconds=50),
             now + timedelta(days=1),
             now + timedelta(days=500),
-            now + timedelta(days=365*2 + 35),
+            now + timedelta(days=365 * 2 + 35),
             # regression tests for bugs in post-release humanize
             now + timedelta(days=10000),
-            now - timedelta(days=365+35),
+            now - timedelta(days=365 + 35),
             30,
-            now - timedelta(days=365*2 + 65),
+            now - timedelta(days=365 * 2 + 65),
             now - timedelta(days=365 + 4),
             "NaN",
         ]
@@ -204,7 +209,7 @@ class TimeTestCase(HumanizeTestCase):
             now - timedelta(days=17),
             now - timedelta(days=47),
             now - timedelta(days=500),
-            now - timedelta(days=365*2 + 35),
+            now - timedelta(days=365 * 2 + 35),
             now + timedelta(seconds=1),
             now + timedelta(seconds=30),
             now + timedelta(minutes=1, seconds=30),
@@ -213,12 +218,12 @@ class TimeTestCase(HumanizeTestCase):
             now + timedelta(hours=23, minutes=50, seconds=50),
             now + timedelta(days=1),
             now + timedelta(days=500),
-            now + timedelta(days=365*2 + 35),
+            now + timedelta(days=365 * 2 + 35),
             # regression tests for bugs in post-release humanize
             now + timedelta(days=10000),
-            now - timedelta(days=365+35),
+            now - timedelta(days=365 + 35),
             30,
-            now - timedelta(days=365*2 + 65),
+            now - timedelta(days=365 * 2 + 65),
             now - timedelta(days=365 + 4),
             "NaN",
         ]
@@ -260,8 +265,8 @@ class TimeTestCase(HumanizeTestCase):
     def test_naturalday(self):
         # Arrange
         today = date.today()
-        tomorrow = today + one_day
-        yesterday = today - one_day
+        tomorrow = today + ONE_DAY
+        yesterday = today - ONE_DAY
 
         someday = date(today.year, 3, 5)
         someday_result = 'Mar 05'
@@ -269,13 +274,29 @@ class TimeTestCase(HumanizeTestCase):
         valerrtest = fakedate(290149024, 2, 2)
         overflowtest = fakedate(120390192341, 2, 2)
 
-        test_list = (today, tomorrow, yesterday, someday, '02/26/1984',
-            (date(1982, 6, 27), '%Y.%m.%d'), None, "Not a date at all.",
-            valerrtest, overflowtest
+        test_list = (
+            today,
+            tomorrow,
+            yesterday,
+            someday,
+            '02/26/1984',
+            (date(1982, 6, 27), '%Y.%m.%d'),
+            None,
+            "Not a date at all.",
+            valerrtest,
+            overflowtest,
         )
-        result_list = ('today', 'tomorrow', 'yesterday', someday_result, '02/26/1984',
-            '1982.06.27', None, "Not a date at all.",
-            valerrtest, overflowtest
+        result_list = (
+            'today',
+            'tomorrow',
+            'yesterday',
+            someday_result,
+            '02/26/1984',
+            '1982.06.27',
+            None,
+            "Not a date at all.",
+            valerrtest,
+            overflowtest,
         )
 
         # Act / Assert
@@ -285,25 +306,34 @@ class TimeTestCase(HumanizeTestCase):
     def test_naturaldate(self):
         # Arrange
         today = date.today()
-        tomorrow = today + one_day
-        yesterday = today - one_day
+        tomorrow = today + ONE_DAY
+        yesterday = today - ONE_DAY
 
         someday = date(today.year, 3, 5)
         someday_result = 'Mar 05'
 
-        test_list = (today, tomorrow, yesterday, someday, date(1982, 6, 27))
-        result_list = ('today', 'tomorrow', 'yesterday', someday_result, 'Jun 27 1982')
+        test_list = (
+            today,
+            tomorrow,
+            yesterday,
+            someday,
+            date(1982, 6, 27),
+            None,
+            "Not a date at all.",
+            VALUE_ERROR_TEST,
+            OVERFLOW_ERROR_TEST,
+        )
+        result_list = (
+            'today',
+            'tomorrow',
+            'yesterday',
+            someday_result,
+            'Jun 27 1982',
+            None,
+            "Not a date at all.",
+            VALUE_ERROR_TEST,
+            OVERFLOW_ERROR_TEST,
+        )
 
         # Act / Assert
         self.assertManyResults(time.naturaldate, test_list, result_list)
-
-    def test_naturaldate_non_dates(self):
-        # Arrange
-        valerrtest = fakedate(290149024, 2, 2)
-        overflowtest = fakedate(120390192341, 2, 2)
-
-        # Act / Assert
-        assert time.naturaldate(None) is None
-        assert time.naturaldate("Not a date at all.") == "Not a date at all."
-        assert time.naturaldate(valerrtest) == valerrtest
-        assert time.naturaldate(overflowtest) == overflowtest

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -15,9 +15,11 @@ from .base import HumanizeTestCase
 today = date.today()
 one_day = timedelta(days=1)
 
+
 class fakedate(object):
     def __init__(self, year, month, day):
         self.year, self.month, self.day = year, month, day
+
 
 class TimeUtilitiesTestCase(HumanizeTestCase):
     """These are not considered "public" interfaces, but require tests anyway."""
@@ -34,6 +36,7 @@ class TimeUtilitiesTestCase(HumanizeTestCase):
                 self.assertEqualDatetime(dt, result[0])
                 self.assertEqualTimedelta(d, result[1])
         self.assertEqual(time.date_and_delta("NaN"), (None, "NaN"))
+
 
 class TimeTestCase(HumanizeTestCase):
     """Tests for the public interface of humanize.time"""
@@ -289,3 +292,13 @@ class TimeTestCase(HumanizeTestCase):
         result_list = ('today', 'tomorrow', 'yesterday', someday_result, 'Jun 27 1982')
         self.assertManyResults(time.naturaldate, test_list, result_list)
 
+    def test_naturaldate_non_dates(self):
+        # Arrange
+        valerrtest = fakedate(290149024, 2, 2)
+        overflowtest = fakedate(120390192341, 2, 2)
+
+        # Act / Assert
+        assert time.naturaldate(None) is None
+        assert time.naturaldate("Not a date at all.") == "Not a date at all."
+        assert time.naturaldate(valerrtest) == valerrtest
+        assert time.naturaldate(overflowtest) == overflowtest

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -10,9 +10,9 @@ except (ImportError, AttributeError):
 
 from humanize import time
 from datetime import date, datetime, timedelta
+from freezegun import freeze_time
 from .base import HumanizeTestCase
 
-today = date.today()
 one_day = timedelta(days=1)
 
 
@@ -256,17 +256,19 @@ class TimeTestCase(HumanizeTestCase):
             nt_nomonths = lambda d: time.naturaltime(d, months=False)
             self.assertManyResults(nt_nomonths, test_list, result_list)
 
+    @freeze_time("2020-02-02")
     def test_naturalday(self):
+        # Arrange
+        today = date.today()
         tomorrow = today + one_day
         yesterday = today - one_day
-        if today.month != 3:
-            someday = date(today.year, 3, 5)
-            someday_result = 'Mar 05'
-        else:
-            someday = date(today.year, 9, 5)
-            someday_result = 'Sep 05'
+
+        someday = date(today.year, 3, 5)
+        someday_result = 'Mar 05'
+
         valerrtest = fakedate(290149024, 2, 2)
         overflowtest = fakedate(120390192341, 2, 2)
+
         test_list = (today, tomorrow, yesterday, someday, '02/26/1984',
             (date(1982, 6, 27), '%Y.%m.%d'), None, "Not a date at all.",
             valerrtest, overflowtest
@@ -275,21 +277,24 @@ class TimeTestCase(HumanizeTestCase):
             '1982.06.27', None, "Not a date at all.",
             valerrtest, overflowtest
         )
+
+        # Act / Assert
         self.assertManyResults(time.naturalday, test_list, result_list)
 
+    @freeze_time("2020-02-02")
     def test_naturaldate(self):
+        # Arrange
+        today = date.today()
         tomorrow = today + one_day
         yesterday = today - one_day
 
-        if today.month != 3:
-            someday = date(today.year, 3, 5)
-            someday_result = 'Mar 05'
-        else:
-            someday = date(today.year, 9, 5)
-            someday_result = 'Sep 05'
+        someday = date(today.year, 3, 5)
+        someday_result = 'Mar 05'
 
         test_list = (today, tomorrow, yesterday, someday, date(1982, 6, 27))
         result_list = ('today', 'tomorrow', 'yesterday', someday_result, 'Jun 27 1982')
+
+        # Act / Assert
         self.assertManyResults(time.naturaldate, test_list, result_list)
 
     def test_naturaldate_non_dates(self):


### PR DESCRIPTION
Includes #88.

* Test `time.naturaldate` with non-dates
* Use freezegun to test with static dates
* Refactor `test_time.py` and format with `black -S`
* Test `i18n.activate` and `deactivate`

https://codecov.io/gh/hugovk/humanize/tree/feae2290057f60056db1c1f035a4a347f41fa7a4