### PR TITLE
Fix invalid date format in test

### DIFF
--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -265,7 +265,7 @@ class TimeTestCase(HumanizeTestCase):
         valerrtest = fakedate(290149024, 2, 2)
         overflowtest = fakedate(120390192341, 2, 2)
         test_list = (today, tomorrow, yesterday, someday, '02/26/1984',
-            (date(1982, 6, 27), '%Y.%M.%D'), None, "Not a date at all.",
+            (date(1982, 6, 27), '%Y.%m.%d'), None, "Not a date at all.",
             valerrtest, overflowtest
         )
         result_list = ('today', 'tomorrow', 'yesterday', someday_result, '02/26/1984',

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -269,7 +269,7 @@ class TimeTestCase(HumanizeTestCase):
             valerrtest, overflowtest
         )
         result_list = ('today', 'tomorrow', 'yesterday', someday_result, '02/26/1984',
-            date(1982, 6, 27).strftime('%Y.%M.%D'), None, "Not a date at all.",
+            '1982.06.27', None, "Not a date at all.",
             valerrtest, overflowtest
         )
         self.assertManyResults(time.naturalday, test_list, result_list)


### PR DESCRIPTION
Fixes #24, replaces and closes #60.

In addition to the invalid date format, there's another problem with the test, in that the unfixed version passes, when it should fail:

https://travis-ci.com/hugovk/humanize/jobs/280093724

It's making the mistake of using the same logic in the input as in the output, and not testing the output for correctness.

Here's some general advice:

* https://testing.googleblog.com/2014/07/testing-on-toilet-dont-put-logic-in.html

It's passing bad input in:

```python
(date(1982, 6, 27), '%Y.%M.%D')
```

But also then comparing that against bad expected output: 

```python
date(1982, 6, 27).strftime('%Y.%M.%D')
```

```python
>>> from datetime import date
>>> date(1982, 6, 27).strftime('%Y.%M.%D')
'1982.00.06/27/82'
>>> date(1982, 6, 27).strftime('%Y.%M.%d')
'1982.00.27'
>>> date(1982, 6, 27).strftime('%Y.%m.%d')
'1982.06.27'
```

So it's really calculating the input and verifying it's the same as the broken `'1982.00.06/27/82'`, when it should check against hardcoded `'1982.06.27'`.

This is needed to show the tests are broken:

```diff
         result_list = ('today', 'tomorrow', 'yesterday', someday_result, '02/26/1984',
-            date(1982, 6, 27).strftime('%Y.%M.%D'), None, "Not a date at all.",
+            '1982.06.27', None, "Not a date at all.",
             valerrtest, overflowtest
         )

```console
$ python setup.py test
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing humanize.egg-info/PKG-INFO
writing dependency_links to humanize.egg-info/dependency_links.txt
writing entry points to humanize.egg-info/entry_points.txt
writing top-level names to humanize.egg-info/top_level.txt
reading manifest template 'MANIFEST.in'
writing manifest file 'humanize.egg-info/SOURCES.txt'
running build_ext
test_naturalsize (tests.filesize.FilesizeTestCase) ... ok
test_apnumber (tests.number.NumberTestCase) ... ok
test_fractional (tests.number.NumberTestCase) ... ok
test_intcomma (tests.number.NumberTestCase) ... ok
test_intword (tests.number.NumberTestCase) ... ok
test_ordinal (tests.number.NumberTestCase) ... ok
test_naturaldate (tests.time.TimeTestCase) ... ok
test_naturalday (tests.time.TimeTestCase) ... FAIL
test_naturaldelta (tests.time.TimeTestCase) ... ok
test_naturaldelta_nomonths (tests.time.TimeTestCase) ... ok
test_naturaltime (tests.time.TimeTestCase) ... ok
test_naturaltime_nomonths (tests.time.TimeTestCase) ... ok
test_date_and_delta (tests.time.TimeUtilitiesTestCase) ... ok

======================================================================
FAIL: test_naturalday (tests.time.TimeTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/private/tmp/humanize/tests/time.py", line 272, in test_naturalday
    self.assertManyResults(time.naturalday, test_list, result_list)
  File "/private/tmp/humanize/tests/base.py", line 16, in assertManyResults
    self.assertEqual(function(*arg), result)
AssertionError: '1982.00.06/27/82' != '1982.06.27'
- 1982.00.06/27/82
+ 1982.06.27


----------------------------------------------------------------------
Ran 13 tests in 0.027s

FAILED (failures=1)
Test failed: <unittest.runner.TextTestResult run=13 errors=0 failures=1>
error: Test failed: <unittest.runner.TextTestResult run=13 errors=0 failures=1>
```

And then this is the full fix:

```diff
diff --git a/tests/time.py b/tests/time.py
index 7747c87..eac3a39 100644
--- a/tests/time.py
+++ b/tests/time.py
@@ -262,11 +262,11 @@ class TimeTestCase(HumanizeTestCase):
         valerrtest = fakedate(290149024, 2, 2)
         overflowtest = fakedate(120390192341, 2, 2)
         test_list = (today, tomorrow, yesterday, someday, '02/26/1984',
-            (date(1982, 6, 27), '%Y.%M.%D'), None, "Not a date at all.",
+            (date(1982, 6, 27), '%Y.%m.%d'), None, "Not a date at all.",
             valerrtest, overflowtest
         )
         result_list = ('today', 'tomorrow', 'yesterday', someday_result, '02/26/1984',
-            date(1982, 6, 27).strftime('%Y.%M.%D'), None, "Not a date at all.",
+            '1982.06.27', None, "Not a date at all.",
             valerrtest, overflowtest
         )
```

```console
$ python setup.py test
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing humanize.egg-info/PKG-INFO
writing dependency_links to humanize.egg-info/dependency_links.txt
writing entry points to humanize.egg-info/entry_points.txt
writing top-level names to humanize.egg-info/top_level.txt
reading manifest template 'MANIFEST.in'
writing manifest file 'humanize.egg-info/SOURCES.txt'
running build_ext
test_naturalsize (tests.filesize.FilesizeTestCase) ... ok
test_apnumber (tests.number.NumberTestCase) ... ok
test_fractional (tests.number.NumberTestCase) ... ok
test_intcomma (tests.number.NumberTestCase) ... ok
test_intword (tests.number.NumberTestCase) ... ok
test_ordinal (tests.number.NumberTestCase) ... ok
test_naturaldate (tests.time.TimeTestCase) ... ok
test_naturalday (tests.time.TimeTestCase) ... ok
test_naturaldelta (tests.time.TimeTestCase) ... ok
test_naturaldelta_nomonths (tests.time.TimeTestCase) ... ok
test_naturaltime (tests.time.TimeTestCase) ... ok
test_naturaltime_nomonths (tests.time.TimeTestCase) ... ok
test_date_and_delta (tests.time.TimeUtilitiesTestCase) ... ok

----------------------------------------------------------------------
Ran 13 tests in 0.016s

OK
```
