### PR TITLE
Allow 3.9-dev to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ python:
  - 3.8
  - 3.9-dev
 
+jobs:
+  allow_failures:
+  - python: 3.9-dev
+
 install:
   - pip install -U pip
   - pip install -U tox-travis


### PR DESCRIPTION
Something with the new virtualenv is making `3.x-dev` fail on Travis CI.

* https://travis-ci.com/hugovk/humanize/builds/148391816
* https://github.com/pypa/virtualenv/issues/1576
* https://travis-ci.community/t/python-development-versions-no-longer-include-pip/7180

Allow it to fail for now:

* https://travis-ci.com/hugovk/humanize/builds/148419307

