### PR TITLE
Revert "Allow 3.9-dev to fail"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ python:
  - 3.8
  - 3.9-dev
 
-jobs:
-  allow_failures:
-  - python: 3.9-dev
-
 install:
   - pip install -U pip
   - pip install -U tox-travis


### PR DESCRIPTION
Reverts jmoiron/humanize#103.

The virtualenv/Travis issues have been fixed, let's make sure the code passes on 3.9-dev.

https://travis-ci.com/hugovk/humanize/builds/148808154
