### PR TITLE
Add scientific notation to string support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,24 @@ If seconds are too large, set `minimum_unit` to milliseconds or microseconds:
 '1'
 ```
 
+### Scientific notation
+
+```pycon
+>>> import humanize
+>>> humanize.scientific(0.3)
+'3.00 x 10⁻¹'
+>>> humanize.scientific(500)
+'5.00 x 10²'
+>>> humanize.scientific("20000")
+'2.00 x 10⁴'
+>>> humanize.scientific(1**10)
+'1.00 x 10⁰'
+>>> humanize.scientific(1**10, precision=1)
+'1.0 x 10⁰'
+>>> humanize.scientific(1**10, precision=0)
+'1 x 10⁰'
+```
+
 ## Localization
 
 How to change locale at runtime:

--- a/src/humanize/__init__.py
+++ b/src/humanize/__init__.py
@@ -1,7 +1,7 @@
 import pkg_resources
 from humanize.filesize import naturalsize
 from humanize.i18n import activate, deactivate
-from humanize.number import apnumber, fractional, intcomma, intword, ordinal
+from humanize.number import apnumber, fractional, intcomma, intword, ordinal, scientific
 from humanize.time import naturaldate, naturalday, naturaldelta, naturaltime
 
 __version__ = VERSION = pkg_resources.get_distribution(__name__).version
@@ -21,5 +21,6 @@ __all__ = [
     "naturalsize",
     "naturaltime",
     "ordinal",
+    "scientific",
     "VERSION",
 ]

--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -148,3 +148,66 @@ def fractional(value):
         return "{:.0f}/{:.0f}".format(numerator, denominator)
     else:
         return "{:.0f} {:.0f}/{:.0f}".format(whole_number, numerator, denominator)
+
+
+def scientific(value, precision=2):
+    """Return number in string scientific notation z.wq x 10ⁿ.
+
+    Examples:
+        float(0.3) will return "3.00 x 10⁻¹"
+        int(500) will return "5.00 x 10²"
+    This will always return a string.
+
+    Args:
+        value (int, float, string): Input number.
+        precision (int): Number of decimal for first part of the number.
+
+    Returns:
+        str: number in scientific notation z.wq x 10ⁿ.
+    """
+    exponents = {
+        "0": "⁰",
+        "1": "¹",
+        "2": "²",
+        "3": "³",
+        "4": "⁴",
+        "5": "⁵",
+        "6": "⁶",
+        "7": "⁷",
+        "8": "⁸",
+        "9": "⁹",
+        "+": "⁺",
+        "-": "⁻",
+    }
+    negative = False
+    try:
+        if "-" in str(value):
+            value = str(value).replace("-", "")
+            negative = True
+
+        if isinstance(value, str):
+            value = float(value)
+
+        fmt = "{:.%se}" % str(int(precision))
+        n = fmt.format(value)
+
+    except (ValueError, TypeError):
+        return value
+
+    part1, part2 = n.split("e")
+    if "-0" in part2:
+        part2 = part2.replace("-0", "-")
+
+    if "+0" in part2:
+        part2 = part2.replace("+0", "")
+
+    new_part2 = []
+    if negative:
+        new_part2.append(exponents["-"])
+
+    for char in part2:
+        new_part2.append(exponents[char])
+
+    final_str = part1 + " x 10" + "".join(new_part2)
+
+    return final_str

--- a/tests/test_filesize.py
+++ b/tests/test_filesize.py
@@ -2,8 +2,8 @@
 
 """Tests for filesize humanizing."""
 
+import humanize
 import pytest
-from humanize import filesize
 
 
 @pytest.mark.parametrize(
@@ -32,4 +32,4 @@ from humanize import filesize
     ],
 )
 def test_naturaltime_minimum_unit_default(test_args, expected):
-    assert filesize.naturalsize(*test_args) == expected
+    assert humanize.naturalsize(*test_args) == expected

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -2,6 +2,7 @@
 
 """Number tests."""
 
+import humanize
 import pytest
 from humanize import number
 
@@ -25,7 +26,7 @@ from humanize import number
     ],
 )
 def test_ordinal(test_input, expected):
-    assert number.ordinal(test_input) == expected
+    assert humanize.ordinal(test_input) == expected
 
 
 @pytest.mark.parametrize(
@@ -47,7 +48,7 @@ def test_ordinal(test_input, expected):
     ],
 )
 def test_intcomma(test_input, expected):
-    assert number.intcomma(test_input) == expected
+    assert humanize.intcomma(test_input) == expected
 
 
 def test_intword_powers():
@@ -74,7 +75,7 @@ def test_intword_powers():
     ],
 )
 def test_intword(test_args, expected):
-    assert number.intword(*test_args) == expected
+    assert humanize.intword(*test_args) == expected
 
 
 @pytest.mark.parametrize(
@@ -91,7 +92,7 @@ def test_intword(test_args, expected):
     ],
 )
 def test_apnumber(test_input, expected):
-    assert number.apnumber(test_input) == expected
+    assert humanize.apnumber(test_input) == expected
 
 
 @pytest.mark.parametrize(
@@ -108,7 +109,7 @@ def test_apnumber(test_input, expected):
     ],
 )
 def test_fractional(test_input, expected):
-    assert number.fractional(test_input) == expected
+    assert humanize.fractional(test_input) == expected
 
 
 @pytest.mark.parametrize(
@@ -130,4 +131,4 @@ def test_fractional(test_input, expected):
     ],
 )
 def test_scientific(test_args, expected):
-    assert number.scientific(*test_args) == expected
+    assert humanize.scientific(*test_args) == expected

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -109,3 +109,25 @@ def test_apnumber(test_input, expected):
 )
 def test_fractional(test_input, expected):
     assert number.fractional(test_input) == expected
+
+
+@pytest.mark.parametrize(
+    "test_args, expected",
+    [
+        ([1000], "1.00 x 10³"),
+        ([-1000], "1.00 x 10⁻³"),
+        ([5.5], "5.50 x 10⁰"),
+        ([5781651000], "5.78 x 10⁹"),
+        (["1000"], "1.00 x 10³"),
+        (["99"], "9.90 x 10¹"),
+        ([float(0.3)], "3.00 x 10⁻¹"),
+        (["foo"], "foo"),
+        ([None], None),
+        ([1000, 1], "1.0 x 10³"),
+        ([float(0.3), 1], "3.0 x 10⁻¹"),
+        ([1000, 0], "1 x 10³"),
+        ([float(0.3), 0], "3 x 10⁻¹"),
+    ],
+)
+def test_scientific(test_args, expected):
+    assert number.scientific(*test_args) == expected

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -4,6 +4,7 @@
 
 import datetime as dt
 
+import humanize
 import pytest
 from freezegun import freeze_time
 from humanize import time
@@ -66,7 +67,7 @@ def test_date_and_delta():
 
 
 def nd_nomonths(d):
-    return time.naturaldelta(d, months=False)
+    return humanize.naturaldelta(d, months=False)
 
 
 @pytest.mark.parametrize(
@@ -118,7 +119,7 @@ def test_naturaldelta_nomonths(test_input, expected):
     ],
 )
 def test_naturaldelta(test_input, expected):
-    assert time.naturaldelta(test_input) == expected
+    assert humanize.naturaldelta(test_input) == expected
 
 
 @freeze_time("2020-02-02")
@@ -154,11 +155,11 @@ def test_naturaldelta(test_input, expected):
     ],
 )
 def test_naturaltime(test_input, expected):
-    assert time.naturaltime(test_input) == expected
+    assert humanize.naturaltime(test_input) == expected
 
 
 def nt_nomonths(d):
-    return time.naturaltime(d, months=False)
+    return humanize.naturaltime(d, months=False)
 
 
 @freeze_time("2020-02-02")
@@ -216,7 +217,7 @@ def test_naturaltime_nomonths(test_input, expected):
     ],
 )
 def test_naturalday(test_args, expected):
-    assert time.naturalday(*test_args) == expected
+    assert humanize.naturalday(*test_args) == expected
 
 
 @freeze_time("2020-02-02")
@@ -260,7 +261,7 @@ def test_naturalday(test_args, expected):
     ],
 )
 def test_naturaldate(test_input, expected):
-    assert time.naturaldate(test_input) == expected
+    assert humanize.naturaldate(test_input) == expected
 
 
 @pytest.mark.parametrize(
@@ -282,7 +283,7 @@ def test_naturaldelta_minimum_unit_default(seconds, expected):
     delta = dt.timedelta(seconds=seconds)
 
     # Act / Assert
-    assert time.naturaldelta(delta) == expected
+    assert humanize.naturaldelta(delta) == expected
 
 
 @pytest.mark.parametrize(
@@ -317,7 +318,7 @@ def test_naturaldelta_minimum_unit_explicit(minimum_unit, seconds, expected):
     delta = dt.timedelta(seconds=seconds)
 
     # Act / Assert
-    assert time.naturaldelta(delta, minimum_unit=minimum_unit) == expected
+    assert humanize.naturaldelta(delta, minimum_unit=minimum_unit) == expected
 
 
 @pytest.mark.parametrize(
@@ -339,7 +340,7 @@ def test_naturaltime_minimum_unit_default(seconds, expected):
     delta = dt.timedelta(seconds=seconds)
 
     # Act / Assert
-    assert time.naturaltime(delta) == expected
+    assert humanize.naturaltime(delta) == expected
 
 
 @pytest.mark.parametrize(
@@ -374,4 +375,4 @@ def test_naturaltime_minimum_unit_explicit(minimum_unit, seconds, expected):
     delta = dt.timedelta(seconds=seconds)
 
     # Act / Assert
-    assert time.naturaltime(delta, minimum_unit=minimum_unit) == expected
+    assert humanize.naturaltime(delta, minimum_unit=minimum_unit) == expected


### PR DESCRIPTION
Closes https://github.com/jmoiron/humanize/pull/76.

Same as https://github.com/jmoiron/humanize/pull/76, with merge conflicts resolved and only docstring, formatting changes. Tests essentially the same, rewritten to `@pytest.mark.parametrize`.

Thanks @Thx3r!

TODO

* [x] Document in README
