### PR TITLE
Don't draft releases in forks

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update_release_draft:
-    if: github.actor == 'repo-owner'
+    if: github.repository == 'jmoiron/humanize'
     runs-on: ubuntu-latest
     steps:
       # Drafts your next release notes as pull requests are merged into "master"


### PR DESCRIPTION
Previous attempt in #114 didn't work: it skipped it in my fork and this repo. Let's try this way.