### PR TITLE
GHA: Send coverage to Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,4 +72,6 @@ jobs:
 
       - name: Upload coverage
         if: success()
-        run: bash <(curl -s https://codecov.io/bash) -F ${{ matrix.codecov-flag }}
+        run: |
+          curl -s https://codecov.io/bash -o codecov.sh
+          ./codecov.sh -F ${{ matrix.codecov-flag }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,14 @@ jobs:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          # Include new variables for Codecov
+          - os: ubuntu-latest
+            codecov-flag: GHA_Ubuntu
+          - os: macOS-latest
+            codecov-flag: GHA_macOS
+          - os: windows-latest
+            codecov-flag: GHA_Windows
 
     steps:
       - uses: actions/checkout@v1
@@ -61,3 +69,7 @@ jobs:
         shell: bash
         run: |
           tox -e py
+
+      - name: Upload coverage
+        if: success()
+        run: bash <(curl -s https://codecov.io/bash) -F ${{ matrix.codecov-flag }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,3 +75,5 @@ jobs:
         run: |
           curl -s https://codecov.io/bash -o codecov.sh
           bash codecov.sh -F ${{ matrix.codecov-flag }}
+        env:
+          CODECOV_NAME: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,4 +74,4 @@ jobs:
         if: success()
         run: |
           curl -s https://codecov.io/bash -o codecov.sh
-          ./codecov.sh -F ${{ matrix.codecov-flag }}
+          bash codecov.sh -F ${{ matrix.codecov-flag }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ script:
   - tox
 
 after_success:
-  - pip install -U codecov && codecov
+  - pip install -U codecov && codecov --flags TravisCI

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
 extras =
     tests
 commands =
-    {envpython} -m pytest --cov humanize --cov tests {posargs}
+    {envpython} -m pytest --cov humanize --cov tests --cov-report xml {posargs}
 
 [testenv:lint]
 deps = pre-commit


### PR DESCRIPTION
Codecov now supports tokenless uploads for GitHub Actions.

https://community.codecov.io/t/whitelist-github-action-servers-to-upload-without-a-token/491/17

![image](https://user-images.githubusercontent.com/1324225/75967492-94c15f80-5ed4-11ea-990b-7162f8af4f6d.png)

![image](https://user-images.githubusercontent.com/1324225/75967516-9ee35e00-5ed4-11ea-8b16-e74a8f1994db.png)

