### PR TITLE
Fix: AP style for 0 is 'zero'

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,6 @@ Fixes #
 
 Changes proposed in this pull request:
 
- * 
- * 
- * 
+* 
+* 
+* 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.0.1
+    rev: v2.1.0
     hooks:
       - id: pyupgrade
         args: ["--py3-plus"]
@@ -18,7 +18,7 @@ repos:
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
 
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.4
+    rev: v2.1.0
     hooks:
       - id: seed-isort-config
 

--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -106,9 +106,15 @@ def intword(value, format="%.1f"):
 
 
 def apnumber(value):
-    """For numbers 0-9, returns the number spelled out. Otherwise, returns the
-    number. This follows Associated Press style.  This always returns a string
-    unless the value was not int-able, unlike the Django filter."""
+    """Converts an integer to Associated Press style.
+
+    Args:
+        value (int, float, string): Integer to convert.
+
+    Returns:
+        str: For numbers 0-9, the number spelled out. Otherwise, the number. This always
+        returns a string unless the value was not int-able, unlike the Django filter.
+    """
     try:
         value = int(value)
     except (TypeError, ValueError):

--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -106,16 +106,17 @@ def intword(value, format="%.1f"):
 
 
 def apnumber(value):
-    """For numbers 1-9, returns the number spelled out. Otherwise, returns the
+    """For numbers 0-9, returns the number spelled out. Otherwise, returns the
     number. This follows Associated Press style.  This always returns a string
     unless the value was not int-able, unlike the Django filter."""
     try:
         value = int(value)
     except (TypeError, ValueError):
         return value
-    if not 0 < value < 10:
+    if not 0 <= value < 10:
         return str(value)
     return (
+        _("zero"),
         _("one"),
         _("two"),
         _("three"),
@@ -125,7 +126,7 @@ def apnumber(value):
         _("seven"),
         _("eight"),
         _("nine"),
-    )[value - 1]
+    )[value]
 
 
 def fractional(value):

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -86,6 +86,7 @@ def test_intword(test_args, expected):
 @pytest.mark.parametrize(
     "test_input, expected",
     [
+        (0, "zero"),
         (1, "one"),
         (2, "two"),
         (4, "four"),


### PR DESCRIPTION
Fixes #72.

Changes proposed in this pull request:

 * AP  style for 0 is "zero", not "0"
 * The _Associated Press Stylebook_ (p. 203) says:
   * **Spell out whole numbers up to (and including) nine** (e.g., zero, one, 10, 96, 104).
 * https://apvschicago.com/2011/05/numbers-spell-out-or-use-numerals.html

# Before

```pycon
>>> import humanize
>>> humanize.apnumber(0)
'0'
>>> humanize.apnumber(1)
'one'
>>> humanize.apnumber(2)
'two'
>>>
```

# After

```pycon
>>> import humanize
>>> humanize.apnumber(0)
'zero'
>>> humanize.apnumber(1)
'one'
>>> humanize.apnumber(2)
'two'
>>>
```
