### PR TITLE
 Explicit error if _DEFAULT_LOCALE_PATH is None

### DIFF
--- a/src/humanize/i18n.py
+++ b/src/humanize/i18n.py
@@ -13,6 +13,7 @@ except AttributeError:
     # in case that __file__ does not exist
     _DEFAULT_LOCALE_PATH = None
 
+
 def get_translation():
     try:
         return _TRANSLATIONS[_CURRENT.locale]
@@ -29,8 +30,9 @@ def activate(locale, path=None):
 
     if path is None:
         raise Exception(
-                "humanize cannot determinate the default location "
-                "of the 'locale' folder. You need to pass the path explicitly.")
+            "Humanize cannot determinate the default location of the 'locale' folder. "
+            "You need to pass the path explicitly."
+        )
     if locale not in _TRANSLATIONS:
         translation = gettext_module.translation("humanize", path, [locale])
         _TRANSLATIONS[locale] = translation

--- a/src/humanize/i18n.py
+++ b/src/humanize/i18n.py
@@ -7,8 +7,11 @@ __all__ = ["activate", "deactivate", "gettext", "ngettext"]
 _TRANSLATIONS = {None: gettext_module.NullTranslations()}
 _CURRENT = local()
 
-_DEFAULT_LOCALE_PATH = os.path.join(os.path.dirname(__file__), "locale")
-
+try:
+    _DEFAULT_LOCALE_PATH = os.path.join(os.path.dirname(__file__), "locale")
+except AttributeError:
+    # in case that __file__ does not exist
+    _DEFAULT_LOCALE_PATH = None
 
 def get_translation():
     try:
@@ -23,6 +26,11 @@ def activate(locale, path=None):
     @param path: path to search for locales"""
     if path is None:
         path = _DEFAULT_LOCALE_PATH
+
+    if path is None:
+        raise Exception(
+                "humanize cannot determinate the default location "
+                "of the 'locale' folder. You need to pass the path explicitly.")
     if locale not in _TRANSLATIONS:
         translation = gettext_module.translation("humanize", path, [locale])
         _TRANSLATIONS[locale] = translation


### PR DESCRIPTION
Try to use `__file__` if possible but do not crash if not.

Instead, when `activate` is used and no explicit path is given, raise an
exception explaining why.

A better alternative could be use `resource_path`
(https://docs.python.org/3/library/importlib.html#importlib.abc.ResourceReader)
to find the directory of 'locale'.

Unfortunately Python (at least 3.7) only allows to access to files
and not folders so we cannot access to 'locale' (a folder)

Closes #81

Changes proposed in this pull request:

* Do not crash if `__file__` does not exist
* Raise an exception if the default path is needed
