### PR TITLE
Fix fractional(0.333) output in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,13 @@ How to change locale at runtime:
 >>> import humanize
 >>> import datetime as dt
 >>> humanize.naturaltime(dt.timedelta(seconds=3))
-3 seconds ago
+'3 seconds ago'
 >>> _t = humanize.i18n.activate("ru_RU")
 >>> humanize.naturaltime(dt.timedelta(seconds=3))
-3 секунды назад
+'3 секунды назад'
 >>> humanize.i18n.deactivate()
 >>> humanize.naturaltime(dt.timedelta(seconds=3))
-3 seconds ago
+'3 seconds ago'
 ```
 
 You can pass additional parameter `path` to `activate` to specify a path to search

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ If seconds are too large, set `minimum_unit` to milliseconds or microseconds:
 >>> humanize.fractional(0.3)
 '3/10'
 >>> humanize.fractional(0.333)
-'1/3'
+'333/1000'
 >>> humanize.fractional(1)
 '1'
 ```

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -123,6 +123,10 @@ def test_apnumber(test_input, expected):
         ("8.9", "8 9/10"),
         ("ten", "ten"),
         (None, None),
+        (1 / 3, "1/3"),
+        (1.5, "1 1/2"),
+        (0.3, "3/10"),
+        (0.333, "333/1000"),
     ],
 )
 def test_fractional(test_input, expected):


### PR DESCRIPTION
Fixes https://github.com/jmoiron/humanize/issues/133.

Changes proposed in this pull request:

* Add the `fractional` examples from the README as test cases 
* Fix the output of `humanize.fractional(0.333)` from `'1/3'` to `'333/1000'` in the README and test case
* Add some missing quotes around string outputs

