### PR TITLE
README: Update expected exception when translation not found

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,3 +37,5 @@ jobs:
 
       - name: Lint
         run: tox -e lint
+        env:
+          PRE_COMMIT_COLOR: always

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.5.0
+    rev: v2.6.1
     hooks:
       - id: pyupgrade
         args: ["--py3-plus"]

--- a/README.md
+++ b/README.md
@@ -165,8 +165,9 @@ locales in.
 
 ```pycon
 >>> import humanize
->>> humanize.i18n.activate("pt_BR")
-IOError: [Errno 2] No translation file found for domain: 'humanize'
+>>> humanize.i18n.activate("xx_XX")
+<...>
+FileNotFoundError: [Errno 2] No translation file found for domain: 'humanize'
 >>> humanize.i18n.activate("pt_BR", path="path/to/my/portuguese/translation/")
 <gettext.GNUTranslations instance ...>
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,6 @@ include_trailing_comma = True
 line_length = 88
 multi_line_output = 3
 use_parentheses = True
+
+[tool:pytest]
+addopts = --color=yes

--- a/tox.ini
+++ b/tox.ini
@@ -10,5 +10,6 @@ commands =
 
 [testenv:lint]
 deps = pre-commit
-commands = pre-commit run --all-files
+commands = pre-commit run --all-files --show-diff-on-failure
 skip_install = true
+passenv = PRE_COMMIT_COLOR


### PR DESCRIPTION
Changes proposed in this pull request:

* Followup to https://github.com/jmoiron/humanize/pull/134
* Found via byexample (re: https://github.com/byexamples/byexample/issues/116)
* Update some test things


---

* Just one thing left, which I don't think needs to be runnable:


```console
$ byexample -x-shebang 'python:/Library/Frameworks/Python.framework/Versions/3.8/bin/python3 %a' -l python -o '+force-echo-filtering +geometry=24x300' README.md

**********************************************************************
File "README.md", line 171
Failed example:
    humanize.i18n.activate("pt_BR", path="path/to/my/portuguese/translation/")
Expected:
<gettext.GNUTranslations instance ...>
Got:
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/hugo/github/humanize/src/humanize/i18n.py", line 27, in activate
    translation = gettext_module.translation("humanize", path, [locale])
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/gettext.py", line 588, in translation
    raise FileNotFoundError(ENOENT,
FileNotFoundError: [Errno 2] No translation file found for domain: 'humanize'


File README.md, 52/52 test ran in 1.03 seconds
[FAIL] Pass: 51 Fail: 1 Skip: 0
```
