### PR TITLE
Function to represent timedeltas without losing precision (precisedelta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,13 @@ readable size or throughput. It is localized to:
 ### Precise time delta
 
 ```pycon
+>>> import humanize
 >>> delta = dt.timedelta(seconds=3633, days=2, microseconds=123000)
 >>> humanize.precisedelta(delta)
 '2 days, 1 hour and 33.12 seconds'
 >>> humanize.precisedelta(delta, minimum_unit="microseconds")
 '2 days, 1 hour, 33 seconds and 123 milliseconds'
->>> humanize.precisedelta(delta, suppress=['days'], format="%0.4f")
+>>> humanize.precisedelta(delta, suppress=["days"], format="%0.4f")
 '49 hours and 33.1230 seconds'
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ readable size or throughput. It is localized to:
 
 ```pycon
 >>> import humanize
+>>> import datetime as dt
 >>> delta = dt.timedelta(seconds=3633, days=2, microseconds=123000)
 >>> humanize.precisedelta(delta)
 '2 days, 1 hour and 33.12 seconds'

--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ readable size or throughput. It is localized to:
 'an hour ago'
 ```
 
+### Precise time delta
+
+```pycon
+>>> delta = dt.timedelta(seconds=3633, days=2, microseconds=123000)
+>>> humanize.precisedelta(delta)
+'2 days, 1 hour and 33.12 seconds'
+>>> humanize.precisedelta(delta, minimum_unit="microseconds")
+'2 days, 1 hour, 33 seconds and 123 milliseconds'
+>>> humanize.precisedelta(delta, suppress=['days'], format="%0.4f")
+'49 hours and 33.1230 seconds'
+```
+
 #### Smaller units
 
 If seconds are too large, set `minimum_unit` to milliseconds or microseconds:

--- a/src/humanize/__init__.py
+++ b/src/humanize/__init__.py
@@ -2,7 +2,13 @@ import pkg_resources
 from humanize.filesize import naturalsize
 from humanize.i18n import activate, deactivate
 from humanize.number import apnumber, fractional, intcomma, intword, ordinal, scientific
-from humanize.time import naturaldate, naturalday, naturaldelta, naturaltime
+from humanize.time import (
+    naturaldate,
+    naturalday,
+    naturaldelta,
+    naturaltime,
+    precisedelta,
+)
 
 __version__ = VERSION = pkg_resources.get_distribution(__name__).version
 
@@ -21,6 +27,7 @@ __all__ = [
     "naturalsize",
     "naturaltime",
     "ordinal",
+    "precisedelta",
     "scientific",
     "VERSION",
 ]

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -5,6 +5,7 @@
 
 import datetime as dt
 from enum import Enum
+from functools import total_ordering
 
 from .i18n import gettext as _
 from .i18n import ngettext
@@ -12,10 +13,22 @@ from .i18n import ngettext
 __all__ = ["naturaldelta", "naturaltime", "naturalday", "naturaldate"]
 
 
+
+@total_ordering
 class Unit(Enum):
-    MILLISECONDS = 0
-    MICROSECONDS = 1
+    MICROSECONDS = 0
+    MILLISECONDS = 1
     SECONDS = 2
+    MINUTES = 3
+    HOURS = 4
+    DAYS = 5
+    MONTHS = 6
+    YEARS = 7
+
+    def __lt__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value < other.value
+        return NotImplemented
 
 
 def _now():

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -80,7 +80,11 @@ def naturaldelta(value, months=True, minimum_unit="seconds"):
     Returns:
         str: A natural representation of the amount of time elapsed.
     """
-    minimum_unit = Unit[minimum_unit.upper()]
+    tmp = Unit[minimum_unit.upper()]
+    if tmp not in (Unit.SECONDS, Unit.MILLISECONDS, Unit.MICROSECONDS):
+        raise ValueError("Minimum unit '%s' not supported" % minimum_unit)
+    minimum_unit = tmp
+
     date, delta = date_and_delta(value)
     if date is None:
         return value

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -235,32 +235,32 @@ def naturaldate(value):
     return naturalday(value)
 
 
-def _quotient_and_remainer(value, divisor, unit, minimum_unit, suppress):
+def _quotient_and_remainder(value, divisor, unit, minimum_unit, suppress):
     """Divide ``value`` by ``divisor`` returning the quotient and
-       the remainer as follows:
+       the remainder as follows:
 
-       If unit is minimum_unit, makes the quotient a float number
-       and the remainer will be zero. The rational is that if unit
+       If ``unit`` is ``minimum_unit``, makes the quotient a float number
+       and the remainder will be zero. The rational is that if unit
        is the unit of the quotient, we cannot
-       represent the remainer because it would require an unit smaller
+       represent the remainder because it would require an unit smaller
        than the minimum_unit.
 
-       >>> from humanize.time import _quotient_and_remainer, Unit
-       >>> _quotient_and_remainer(36, 24, Unit.DAYS, Unit.DAYS, [])
+       >>> from humanize.time import _quotient_and_remainder, Unit
+       >>> _quotient_and_remainder(36, 24, Unit.DAYS, Unit.DAYS, [])
        (1.5, 0)
 
        If unit is in suppress, the quotient will be zero and the
-       remainer will be the initial value. The idea is that if we
+       remainder will be the initial value. The idea is that if we
        cannot use unit, we are forced to use a lower unit so we cannot
        do the division.
 
-       >>> _quotient_and_remainer(36, 24, Unit.DAYS, Unit.HOURS, [Unit.DAYS])
+       >>> _quotient_and_remainder(36, 24, Unit.DAYS, Unit.HOURS, [Unit.DAYS])
        (0, 36)
 
-       In other case return quotient and remainer as ``divmod`` would
+       In other case return quotient and remainder as ``divmod`` would
        do it.
 
-       >>> _quotient_and_remainer(36, 24, Unit.DAYS, Unit.HOURS, [])
+       >>> _quotient_and_remainder(36, 24, Unit.DAYS, Unit.HOURS, [])
        (1, 12)
 
     """
@@ -330,7 +330,7 @@ def _suitable_minimum_unit(min_unit, suppress):
                 return unit
 
         raise ValueError(
-            "Minimum unit is suppresed and not suitable replacement was found"
+            "Minimum unit is suppressed and not suitable replacement was found"
         )
 
     return min_unit
@@ -371,7 +371,7 @@ def precisedelta(value, minimum_unit="seconds", suppress=(), format="%0.2f"):
 
        Instead, the minimum unit can be changed to have a better resolution;
        the function still will readjust the unit to use the greatest of the
-       units that does not loose precision.
+       units that does not lose precision.
 
        For example setting microseconds but still representing the date
        with milliseconds:
@@ -401,7 +401,7 @@ def precisedelta(value, minimum_unit="seconds", suppress=(), format="%0.2f"):
 
     suppress = [Unit[s.upper()] for s in suppress]
 
-    # Find a suitable minimum unit (it an be greater the one that the
+    # Find a suitable minimum unit (it can be greater the one that the
     # user gave us if it is suppressed.
     min_unit = Unit[minimum_unit.upper()]
     min_unit = _suitable_minimum_unit(min_unit, suppress)
@@ -432,8 +432,8 @@ def precisedelta(value, minimum_unit="seconds", suppress=(), format="%0.2f"):
     #       years, days = divmod(years, days)
     #
     # The same applies for months, hours, minutes and milliseconds below
-    years, days = _quotient_and_remainer(days, 365, YEARS, min_unit, suppress)
-    months, days = _quotient_and_remainer(days, 30.5, MONTHS, min_unit, suppress)
+    years, days = _quotient_and_remainder(days, 365, YEARS, min_unit, suppress)
+    months, days = _quotient_and_remainder(days, 30.5, MONTHS, min_unit, suppress)
 
     # If DAYS is not in suppress, we can represent the days but
     # if it is a suppressed unit, we need to carry it to a lower unit,
@@ -442,12 +442,14 @@ def precisedelta(value, minimum_unit="seconds", suppress=(), format="%0.2f"):
     # The same applies for secs and usecs below
     days, secs = _carry(days, secs, 24 * 3600, DAYS, min_unit, suppress)
 
-    hours, secs = _quotient_and_remainer(secs, 3600, HOURS, min_unit, suppress)
-    minutes, secs = _quotient_and_remainer(secs, 60, MINUTES, min_unit, suppress)
+    hours, secs = _quotient_and_remainder(secs, 3600, HOURS, min_unit, suppress)
+    minutes, secs = _quotient_and_remainder(secs, 60, MINUTES, min_unit, suppress)
 
     secs, usecs = _carry(secs, usecs, 1e6, SECONDS, min_unit, suppress)
 
-    msecs, usecs = _quotient_and_remainer(usecs, 1000, MILLISECONDS, min_unit, suppress)
+    msecs, usecs = _quotient_and_remainder(
+        usecs, 1000, MILLISECONDS, min_unit, suppress
+    )
 
     # if _unused != 0 we had lost some precision
     usecs, _unused = _carry(usecs, 0, 1, MICROSECONDS, min_unit, suppress)

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -242,7 +242,7 @@ def _quotient_and_remainder(value, divisor, unit, minimum_unit, suppress):
        If ``unit`` is ``minimum_unit``, makes the quotient a float number
        and the remainder will be zero. The rational is that if unit
        is the unit of the quotient, we cannot
-       represent the remainder because it would require an unit smaller
+       represent the remainder because it would require a unit smaller
        than the minimum_unit.
 
        >>> from humanize.time import _quotient_and_remainder, Unit
@@ -330,7 +330,7 @@ def _suitable_minimum_unit(min_unit, suppress):
                 return unit
 
         raise ValueError(
-            "Minimum unit is suppressed and not suitable replacement was found"
+            "Minimum unit is suppressed and no suitable replacement was found"
         )
 
     return min_unit
@@ -402,7 +402,7 @@ def precisedelta(value, minimum_unit="seconds", suppress=(), format="%0.2f"):
     suppress = [Unit[s.upper()] for s in suppress]
 
     # Find a suitable minimum unit (it can be greater the one that the
-    # user gave us if it is suppressed.
+    # user gave us if it is suppressed).
     min_unit = Unit[minimum_unit.upper()]
     min_unit = _suitable_minimum_unit(min_unit, suppress)
     del minimum_unit

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -591,11 +591,11 @@ def assertRaises(func, exception_class, *args, **kargs):
 def test_precisedelta_bogus_call():
     assert humanize.precisedelta(None) is None
 
-    assertRaises(
-        humanize.precisedelta, ValueError, 1, minimum_unit="years", suppress=["years"]
-    )
+    with pytest.raises(ValueError):
+        humanize.precisedelta(1, minimum_unit="years", suppress=["years"])
 
-    assertRaises(humanize.naturaldelta, ValueError, 1, minimum_unit="years")
+    with pytest.raises(ValueError):
+        humanize.naturaldelta(1, minimum_unit="years")
 
 
 def test_time_unit():
@@ -604,4 +604,5 @@ def test_time_unit():
     assert years > minutes
     assert minutes == minutes
 
-    assertRaises(lambda: years < "foo", TypeError)
+    with pytest.raises(TypeError):
+        years < "foo"

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -577,17 +577,6 @@ def test_precisedelta_suppress_units(val, min_unit, suppress, expected):
     )
 
 
-def assertRaises(func, exception_class, *args, **kargs):
-    try:
-        func(*args, **kargs)
-    except Exception as e:
-        if isinstance(e, exception_class):
-            assert True
-            return
-
-    assert False
-
-
 def test_precisedelta_bogus_call():
     assert humanize.precisedelta(None) is None
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -575,3 +575,33 @@ def test_precisedelta_suppress_units(val, min_unit, suppress, expected):
     assert (
         humanize.precisedelta(val, minimum_unit=min_unit, suppress=suppress) == expected
     )
+
+
+def assertRaises(func, exception_class, *args, **kargs):
+    try:
+        func(*args, **kargs)
+    except Exception as e:
+        if isinstance(e, exception_class):
+            assert True
+            return
+
+    assert False
+
+
+def test_precisedelta_bogus_call():
+    assert humanize.precisedelta(None) is None
+
+    assertRaises(
+        humanize.precisedelta, ValueError, 1, minimum_unit="years", suppress=["years"]
+    )
+
+    assertRaises(humanize.naturaldelta, ValueError, 1, minimum_unit="years")
+
+
+def test_time_unit():
+    years, minutes = time.Unit["YEARS"], time.Unit["MINUTES"]
+    assert minutes < years
+    assert years > minutes
+    assert minutes == minutes
+
+    assertRaises(lambda: years < "foo", TypeError)


### PR DESCRIPTION
Fixes #48 

Changes proposed in this pull request:

* Extend Unit enum to have all the time units handled by `humanize` (years, months, ...)
* Be able to order the time units (`Unit.YEARS < Unit.MONTHS` for example)   
* Implement a `precisedelta` function to represent timedeltas without losing precision (fixes #48, supersedes  #57)

Current limitations:
 - The comma `,` is used as separator. It could be easily changed but still we should consider the localization for this.
 - The ` and ` is used to join the last item. Translation is required.
 - If microseconds are used but seconds, milliseconds and microseconds are suppressed, the microseconds are lost.

Examples:

Return a precise representation of a timedelta

```python
>>> import datetime as dt
>>> from humanize.time import precisedelta

>>> delta = dt.timedelta(seconds=3633, days=2, microseconds=123000)
>>> precisedelta(delta)
'2 days, 1 hour and 33.12 seconds'
```
A custom format can be specified to control how the fractional part
is represented:

```python
>>> precisedelta(delta, format="%0.4f")
'2 days, 1 hour and 33.1230 seconds'
```

Instead, the minimum unit can be changed to have a better resolution;
the function still will readjust the unit to use the greatest of the
units that does not loose precision.

For example setting microseconds but still representing the date
with milliseconds:

```python
>>> precisedelta(delta, minimum_unit="microseconds")
'2 days, 1 hour, 33 seconds and 123 milliseconds'
```

If desired, some units can be suppressed: you will not see them
represented and the time of the other units will be adjusted
to keep representing the same timedelta:

```python
>>> precisedelta(delta, suppress=['days'])
'49 hours and 33.12 seconds'
```

Note that microseconds precision is lost if the seconds and all                                                         
the units below are suppressed:                                                                                         
      
```python                                                                                                                         
>>> delta = dt.timedelta(seconds=90, microseconds=100)                                                                  
>>> precisedelta(delta, suppress=['seconds', 'milliseconds', 'microseconds'])                                           
'1.50 minutes' 
```