### PR TITLE
Build API reference docs from docstrings using MKDocs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+name: Docs
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: docs-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            docs-
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U tox
+
+      - name: Docs
+        run: tox -e docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: docs-${{ hashFiles('**/setup.py') }}
+          key: docs-${{ hashFiles('**/tox.ini') }}
           restore-keys: |
             docs-
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,26 +4,20 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: pip cache
-        uses: actions/cache@v1
+      - name: Cache
+        uses: actions/cache@v2
         with:
-          path: ~/.cache/pip
-          key: lint-pip-${{ hashFiles('**/setup.py') }}
+          path: |
+            ~/.cache/pip
+            ~/.cache/pre-commit
+          key: lint-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/.pre-commit-config.yaml') }}
           restore-keys: |
-            lint-pip-
-
-      - name: pre-commit cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.cache/pre-commit
-          key: lint-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
-          restore-keys: |
-            lint-pre-commit-
+            lint-
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           echo "::set-output name=dir::$(pip cache dir)"
 
       - name: pip cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key:

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ build
 dist
 docs/_build*
 htmlcov
+site
 tags

--- a/docs/filesize.md
+++ b/docs/filesize.md
@@ -1,0 +1,3 @@
+# Filesize
+
+::: humanize.filesize

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,3 @@
+# Internationalisation
+
+::: humanize.i18n

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,11 @@
+# humanize
+
+Welcome to the humanize API reference.
+
+* [Number](number)
+* [Time](time)
+* [Filesize](filesize)
+* [I18n](i18n)
+
+Or see [README.md](https://github.com/jmoiron/humanize/blob/master/README.md)
+for usage examples.

--- a/docs/number.md
+++ b/docs/number.md
@@ -1,0 +1,3 @@
+# Number
+
+::: humanize.number

--- a/docs/time.md
+++ b/docs/time.md
@@ -1,0 +1,3 @@
+# Time
+
+::: humanize.time

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,6 @@
 site_name: humanize
+site_url: https://example.com/docs/TODO
+repo_url: https://github.com/jmoiron/humanize
 theme:
   name: "material"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,16 @@
+site_name: humanize
+theme:
+  name: "material"
+
+nav:
+  - Home: index.md
+  - Number: number.md
+  - Time: time.md
+  - Filesize: filesize.md
+  - Internationalisation: i18n.md
+
+plugins:
+  - search
+  - mkdocstrings:
+      watch:
+        - src/humanize

--- a/src/humanize/filesize.py
+++ b/src/humanize/filesize.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""Bits & Bytes related humanization."""
+"""Bits and bytes related humanization."""
 
 suffixes = {
     "decimal": ("kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"),
@@ -10,18 +10,18 @@ suffixes = {
 
 
 def naturalsize(value, binary=False, gnu=False, format="%.1f"):
-    """Format a number of bytes like a human readable filesize (eg. 10 kB).
+    """Format a number of bytes like a human readable filesize (e.g. 10 kB).
 
     By default, decimal suffixes (kB, MB) are used.
 
-    Non-gnu modes are compatible with jinja2's ``filesizeformat`` filter.
+    Non-GNU modes are compatible with jinja2's `filesizeformat` filter.
 
     Args:
-        value (int, float, string): Integer to convert.
-        binary (Boolean): If `True`, uses binary suffixes (KiB, MiB) with base 2**10
-        instead of 10**3.
-        gnu (Boolean): If `True`, the binary argument is ignored and GNU-style
-        (`ls -sh` style) prefixes are used (K, M) with the 2**10 definition.
+        value (int, float, str): Integer to convert.
+        binary (bool): If `True`, uses binary suffixes (KiB, MiB) with base
+            2<sup>10</sup> instead of 10<sup>3</sup>.
+        gnu (bool): If `True`, the binary argument is ignored and GNU-style
+            (`ls -sh` style) prefixes are used (K, M) with the 2**10 definition.
         format (str): Custom formatter.
     """
     if gnu:

--- a/src/humanize/i18n.py
+++ b/src/humanize/i18n.py
@@ -22,9 +22,17 @@ def get_translation():
 
 
 def activate(locale, path=None):
-    """Set 'locale' as current locale. Search for locale in directory 'path'
-    @param locale: language name, eg 'en_GB'
-    @param path: path to search for locales"""
+    """Activate internationalisation.
+
+    Set `locale` as current locale. Search for locale in directory `path`.
+
+    Args:
+        locale (str): Language name, e.g. `en_GB`.
+        path (str): Path to search for locales.
+
+    Returns:
+        dict: Translations.
+    """
     if path is None:
         path = _DEFAULT_LOCALE_PATH
 
@@ -41,19 +49,37 @@ def activate(locale, path=None):
 
 
 def deactivate():
+    """Deactivate internationalisation."""
     _CURRENT.locale = None
 
 
 def gettext(message):
+    """Get translation.
+
+    Args:
+        message (str): Text to translate.
+
+    Returns:
+        str: Translated text.
+    """
     return get_translation().gettext(message)
 
 
 def pgettext(msgctxt, message):
     """'Particular gettext' function.
-    It works with 'msgctxt' .po modifiers and allow duplicate keys with
-    different translations.
-    This GNU gettext function was added in Python 3.8, so for older versions we
-    reimplement it. It works by joining msgctx and msgid by '4' byte."""
+
+    It works with `msgctxt` .po modifiers and allows duplicate keys with different
+    translations.
+
+    Args:
+        msgctxt (str): Context of the translation.
+        message (str): Text to translate.
+
+    Returns:
+        str: Translated text.
+    """
+    # This GNU gettext function was added in Python 3.8, so for older versions we
+    # reimplement it. It works by joining `msgctx` and `message` by '4' byte.
     try:
         # Python 3.8+
         return get_translation().pgettext(msgctxt, message)
@@ -65,12 +91,34 @@ def pgettext(msgctxt, message):
 
 
 def ngettext(message, plural, num):
+    """Plural version of gettext.
+
+    Args:
+        message (str): Singlular text to translate.
+        plural (str): Plural text to translate.
+        num (str): The number (e.g. item count) to determine translation for the
+            respective grammatical number.
+
+    Returns:
+        str: Translated text.
+    """
     return get_translation().ngettext(message, plural, num)
 
 
 def gettext_noop(message):
-    """Example usage:
+    """Mark a string as a translation string without translating it.
+
+    Example usage:
+    ```python
     CONSTANTS = [gettext_noop('first'), gettext_noop('second')]
     def num_name(n):
-        return gettext(CONSTANTS[n])"""
+        return gettext(CONSTANTS[n])
+    ```
+
+    Args:
+        message (str): Text to translate in the future.
+
+    Returns:
+        str: Original text, unchanged.
+    """
     return message

--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -11,9 +11,18 @@ from .i18n import pgettext as P_
 
 
 def ordinal(value):
-    """Converts an integer to its ordinal as a string. 1 is '1st', 2 is '2nd',
-    3 is '3rd', etc. Works for any integer or anything int() will turn into an
-    integer.  Anything other value will have nothing done to it."""
+    """Converts an integer to its ordinal as a string.
+
+    For example, 1 is "1st", 2 is "2nd", 3 is "3rd", etc. Works for any integer or
+    anything `int()` will turn into an integer. Anything other value will have nothing
+    done to it.
+
+    Args:
+        value (int, str, float): Integer to convert.
+
+    Returns:
+        str: Ordinal string.
+    """
     try:
         value = int(value)
     except (TypeError, ValueError):
@@ -39,11 +48,11 @@ def intcomma(value, ndigits=None):
     """Converts an integer to a string containing commas every three digits.
 
     For example, 3000 becomes "3,000" and 45000 becomes "45,000". To maintain some
-    compatibility with Django's intcomma, this function also accepts floats.
+    compatibility with Django's `intcomma`, this function also accepts floats.
 
     Args:
-        value (int, float, string): Integer or float to convert.
-        ndigits (int, None): digits of precision for rounding after the decimal point.
+        value (int, float, str): Integer or float to convert.
+        ndigits (int, None): Digits of precision for rounding after the decimal point.
 
     Returns:
         str: string containing commas every three digits.
@@ -92,13 +101,13 @@ def intword(value, format="%.1f"):
     decillion (33 digits) and googol (100 digits).
 
     Args:
-        value (int, float, string): Integer to convert.
-        format (str): to change the number of decimal or general format of the number
+        value (int, float, str): Integer to convert.
+        format (str): To change the number of decimal or general format of the number
             portion.
 
     Returns:
-        str: friendly text representation as a string, unless the value passed could not
-        be coaxed into an int.
+        str: Friendly text representation as a string, unless the value passed could not
+        be coaxed into an `int`.
     """
     try:
         value = int(value)
@@ -122,11 +131,11 @@ def apnumber(value):
     """Converts an integer to Associated Press style.
 
     Args:
-        value (int, float, string): Integer to convert.
+        value (int, float, str): Integer to convert.
 
     Returns:
         str: For numbers 0-9, the number spelled out. Otherwise, the number. This always
-        returns a string unless the value was not int-able, unlike the Django filter.
+        returns a string unless the value was not `int`-able, unlike the Django filter.
     """
     try:
         value = int(value)
@@ -149,21 +158,36 @@ def apnumber(value):
 
 
 def fractional(value):
-    """
-    There will be some cases where one might not want to show
-        ugly decimal places for floats and decimals.
-    This function returns a human readable fractional number
-        in form of fractions and mixed fractions.
-    Pass in a string, or a number or a float, and this function returns
-        a string representation of a fraction
-        or whole number
-        or a mixed fraction
+    """Convert to fractional number.
+
+    There will be some cases where one might not want to show ugly decimal places for
+    floats and decimals.
+
+    This function returns a human-readable fractional number in form of fractions and
+    mixed fractions.
+
+    Pass in a string, or a number or a float, and this function returns:
+
+    * a string representation of a fraction
+    * or a whole number
+    * or a mixed fraction
+
     Examples:
-        fractional(0.3) will return '1/3'
-        fractional(1.3) will return '1 3/10'
-        fractional(float(1/3)) will return '1/3'
-        fractional(1) will return '1'
-    This will always return a string.
+        ```pycon
+        >>> fractional(0.3)
+        '3/10'
+        >>> fractional(1.3)
+        '1 3/10'
+        >>> fractional(float(1/3))
+        '1/3'
+        >>> fractional(1)
+        '1'
+        ```
+    Args:
+        value (int, float, str): Integer to convert.
+
+    Returns:
+        str: Fractional number as a string.
     """
     try:
         number = float(value)
@@ -187,16 +211,19 @@ def scientific(value, precision=2):
     """Return number in string scientific notation z.wq x 10ⁿ.
 
     Examples:
-        float(0.3) will return "3.00 x 10⁻¹"
-        int(500) will return "5.00 x 10²"
-    This will always return a string.
+        ```pycon
+        >>> scientific(float(0.3))
+        '3.00 x 10⁻¹'
+        >>> scientific(int(500))
+        '5.00 x 10²'
+        ```
 
     Args:
-        value (int, float, string): Input number.
+        value (int, float, str): Input number.
         precision (int): Number of decimal for first part of the number.
 
     Returns:
-        str: number in scientific notation z.wq x 10ⁿ.
+        str: Number in scientific notation z.wq x 10ⁿ.
     """
     exponents = {
         "0": "⁰",

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-"""Time humanizing functions.  These are largely borrowed from Django's
-``contrib.humanize``."""
+"""Time humanizing functions. These are largely borrowed from Django's
+`contrib.humanize`."""
 
 import datetime as dt
 import math
@@ -42,8 +42,15 @@ def _now():
 
 
 def abs_timedelta(delta):
-    """Returns an "absolute" value for a timedelta, always representing a
-    time distance."""
+    """Return an "absolute" value for a timedelta, always representing a
+    time distance.
+
+    Args:
+        delta (datetime.timedelta): Input timedelta.
+
+    Returns:
+        datetime.timedelta: Absolute timedelta.
+    """
     if delta.days < 0:
         now = _now()
         return now - (now + delta)
@@ -51,8 +58,10 @@ def abs_timedelta(delta):
 
 
 def date_and_delta(value, *, now=None):
-    """Turn a value into a date and a timedelta which represents how long ago
-    it was.  If that's not possible, return (None, value)."""
+    """Turn a value into a date and a timedelta which represents how long ago it was.
+
+    If that's not possible, return `(None, value)`.
+    """
     if not now:
         now = _now()
     if isinstance(value, dt.datetime):
@@ -74,14 +83,14 @@ def date_and_delta(value, *, now=None):
 def naturaldelta(value, months=True, minimum_unit="seconds"):
     """Return a natural representation of a timedelta or number of seconds.
 
-    This is similar to naturaltime, but does not add tense to the result.
+    This is similar to `naturaltime`, but does not add tense to the result.
 
     Args:
-        value: A timedelta or a number of seconds.
-        months: If True, then a number of months (based on 30.5 days) will be used for
-            fuzziness between years.
-        minimum_unit: If microseconds or milliseconds, use those units for subsecond
-            deltas.
+        value (datetime.timedelta): A timedelta or a number of seconds.
+        months (bool): If `True`, then a number of months (based on 30.5 days) will be
+            used for fuzziness between years.
+        minimum_unit (str): If microseconds or milliseconds, use those units for
+            subsecond deltas.
 
     Returns:
         str: A natural representation of the amount of time elapsed.
@@ -164,17 +173,17 @@ def naturaldelta(value, months=True, minimum_unit="seconds"):
 def naturaltime(value, future=False, months=True, minimum_unit="seconds"):
     """Return a natural representation of a time in a resolution that makes sense.
 
-    This is more or less compatible with Django's naturaltime filter.
+    This is more or less compatible with Django's `naturaltime` filter.
 
     Args:
-        value: A timedate or a number of seconds.
-        future: Ignored for datetimes, where the tense is always figured out based on
-            the current time. For integers, the return value will be past tense by
-            default, unless future is True.
-        months: If True, then a number of months (based on 30.5 days) will be used for
-            fuzziness between years.
-        minimum_unit: If microseconds or milliseconds, use those units for subsecond
-            times.
+        value (datetime.datetime, int): A `datetime` or a number of seconds.
+        future (bool): Ignored for `datetime`s, where the tense is always figured out
+            based on the current time. For integers, the return value will be past tense
+            by default, unless future is `True`.
+        months (bool): If `True`, then a number of months (based on 30.5 days) will be
+            used for fuzziness between years.
+        minimum_unit (str): If "microseconds" or "milliseconds", use those units for
+            subsecond times.
 
     Returns:
         str: A natural representation of the input in a resolution that makes sense.
@@ -199,7 +208,7 @@ def naturaltime(value, future=False, months=True, minimum_unit="seconds"):
 def naturalday(value, format="%b %d"):
     """For date values that are tomorrow, today or yesterday compared to
     present day returns representing string. Otherwise, returns a string
-    formatted according to ``format``."""
+    formatted according to `format`."""
     try:
         value = dt.date(value.year, value.month, value.day)
     except AttributeError:
@@ -219,7 +228,7 @@ def naturalday(value, format="%b %d"):
 
 
 def naturaldate(value):
-    """Like naturalday, but append a year for dates more than about five months away.
+    """Like `naturalday`, but append a year for dates more than about five months away.
     """
     try:
         value = dt.date(value.year, value.month, value.day)
@@ -236,10 +245,10 @@ def naturaldate(value):
 
 
 def _quotient_and_remainder(value, divisor, unit, minimum_unit, suppress):
-    """Divide ``value`` by ``divisor`` returning the quotient and
+    """Divide `value` by `divisor` returning the quotient and
        the remainder as follows:
 
-       If ``unit`` is ``minimum_unit``, makes the quotient a float number
+       If `unit` is `minimum_unit`, makes the quotient a float number
        and the remainder will be zero. The rational is that if unit
        is the unit of the quotient, we cannot
        represent the remainder because it would require a unit smaller
@@ -257,7 +266,7 @@ def _quotient_and_remainder(value, divisor, unit, minimum_unit, suppress):
        >>> _quotient_and_remainder(36, 24, Unit.DAYS, Unit.HOURS, [Unit.DAYS])
        (0, 36)
 
-       In other case return quotient and remainder as ``divmod`` would
+       In other case return quotient and remainder as `divmod` would
        do it.
 
        >>> _quotient_and_remainder(36, 24, Unit.DAYS, Unit.HOURS, [])
@@ -356,43 +365,50 @@ def _suppress_lower_units(min_unit, suppress):
 def precisedelta(value, minimum_unit="seconds", suppress=(), format="%0.2f"):
     """Return a precise representation of a timedelta.
 
-       >>> import datetime as dt
-       >>> from humanize.time import precisedelta
+    ```pycon
+    >>> import datetime as dt
+    >>> from humanize.time import precisedelta
 
-       >>> delta = dt.timedelta(seconds=3633, days=2, microseconds=123000)
-       >>> precisedelta(delta)
-       '2 days, 1 hour and 33.12 seconds'
+    >>> delta = dt.timedelta(seconds=3633, days=2, microseconds=123000)
+    >>> precisedelta(delta)
+    '2 days, 1 hour and 33.12 seconds'
+    ```
 
-       A custom format can be specified to control how the fractional part
-       is represented:
+    A custom `format` can be specified to control how the fractional part
+    is represented:
 
-       >>> precisedelta(delta, format="%0.4f")
-       '2 days, 1 hour and 33.1230 seconds'
+    ```pycon
+    >>> precisedelta(delta, format="%0.4f")
+    '2 days, 1 hour and 33.1230 seconds'
+    ```
 
-       Instead, the minimum unit can be changed to have a better resolution;
-       the function still will readjust the unit to use the greatest of the
-       units that does not lose precision.
+    Instead, the `minimum_unit` can be changed to have a better resolution;
+    the function will still readjust the unit to use the greatest of the
+    units that does not lose precision.
 
-       For example setting microseconds but still representing the date
-       with milliseconds:
+    For example setting microseconds but still representing the date with milliseconds:
 
-       >>> precisedelta(delta, minimum_unit="microseconds")
-       '2 days, 1 hour, 33 seconds and 123 milliseconds'
+    ```pycon
+    >>> precisedelta(delta, minimum_unit="microseconds")
+    '2 days, 1 hour, 33 seconds and 123 milliseconds'
+    ```
 
-       If desired, some units can be suppressed: you will not see them
-       represented and the time of the other units will be adjusted
-       to keep representing the same timedelta:
+    If desired, some units can be suppressed: you will not see them represented and the
+    time of the other units will be adjusted to keep representing the same timedelta:
 
-       >>> precisedelta(delta, suppress=['days'])
-       '49 hours and 33.12 seconds'
+    ```pycon
+    >>> precisedelta(delta, suppress=['days'])
+    '49 hours and 33.12 seconds'
+    ```
 
-       Note that microseconds precision is lost if the seconds and all
-       the units below are suppressed:
+    Note that microseconds precision is lost if the seconds and all
+    the units below are suppressed:
 
-       >>> delta = dt.timedelta(seconds=90, microseconds=100)
-       >>> precisedelta(delta, suppress=['seconds', 'milliseconds', 'microseconds'])
-       '1.50 minutes'
-
+    ```pycon
+    >>> delta = dt.timedelta(seconds=90, microseconds=100)
+    >>> precisedelta(delta, suppress=['seconds', 'milliseconds', 'microseconds'])
+    '1.50 minutes'
+    ```
     """
 
     date, delta = date_and_delta(value)

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,13 @@ extras =
 commands =
     {envpython} -m pytest --cov humanize --cov tests --cov-report xml {posargs}
 
+[testenv:docs]
+deps =
+    mkdocs
+    mkdocs-material
+    mkdocstrings
+commands = mkdocs build
+
 [testenv:lint]
 deps = pre-commit
 commands = pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
For https://github.com/jmoiron/humanize/issues/139.



Changes proposed in this pull request:

* First part for https://github.com/jmoiron/humanize/issues/139: build the docs from the docstrings (deploy to RTD or `gh-pages` follow)
* Update most docstrings to follow the same format (still a few to do, can be updated later)
* Also some `v2` updates to `lint.yml` and `test.yml`

# To test locally

```sh
pip install -U mkdocs mkdocs-material mkdocstrings
mkdocs build
# or
mkdocs serve
```

