### PR TITLE
Deploy docs to Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,2 @@
+python:
+    install: true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/humanize.svg?logo=pypi&logoColor=FFE873)](https://pypi.org/project/humanize/)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/humanize.svg?logo=python&logoColor=FFE873)](https://pypi.org/project/humanize/)
+[![Documentation Status](https://readthedocs.org/projects/python-humanize/badge/?version=latest)](https://python-humanize.readthedocs.io/en/latest/?badge=latest)
 [![PyPI downloads](https://img.shields.io/pypi/dm/humanize.svg)](https://pypistats.org/packages/humanize)
 [![Travis CI Status](https://travis-ci.com/hugovk/humanize.svg?branch=master)](https://travis-ci.com/hugovk/humanize)
 [![GitHub Actions status](https://github.com/jmoiron/humanize/workflows/Test/badge.svg)](https://github.com/jmoiron/humanize/actions)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs>=1.1
+mkdocs-material
+mkdocstrings

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: humanize
-site_url: https://example.com/docs/TODO
+site_url: https://python-humanize.readthedocs.io
 repo_url: https://github.com/jmoiron/humanize
 theme:
   name: "material"

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,7 @@ commands =
     {envpython} -m pytest --cov humanize --cov tests --cov-report xml {posargs}
 
 [testenv:docs]
-deps =
-    mkdocs
-    mkdocs-material
-    mkdocstrings
+deps = -r docs/requirements.txt
 commands = mkdocs build
 
 [testenv:lint]


### PR DESCRIPTION
For https://github.com/jmoiron/humanize/issues/139.

Changes proposed in this pull request:

* Follow on from https://github.com/jmoiron/humanize/pull/147
* Most of the second part for https://github.com/jmoiron/humanize/issues/139: deploy to Read the Docs
* https://humanize.readthedocs.io is already registered for this project, and I'll ask for access, but in the meantime I've made https://python-humanize.readthedocs.io to get the config all in order
