### PR TITLE
Add explicit setuptools dependency for pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     use_scm_version={"local_scheme": local_scheme},
+    install_requires=["setuptools"],  # pkg_resources
     setup_requires=["setuptools_scm"],
     extras_require={"tests": ["freezegun", "pytest", "pytest-cov"]},
     python_requires=">=3.6",


### PR DESCRIPTION
Since the package uses pkg_resources, add an explicit install_requires
for setuptools.  While it is not technically required to install it
right now, it is going to help distribution packagers notice
the necessity of using a runtime dependency (vs the usual build-time
dependency).