### PR TITLE
Include locales when installing the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,4 +54,5 @@ setup(
         "Topic :: Text Processing",
         "Topic :: Text Processing :: General",
     ],
+    package_data={"humanize": ["locale/*"]}
 )


### PR DESCRIPTION
Therefore when installing through a package manager, like
Alpine's apk or Arch's pacman, all locales will also be available

Fixes locales being missed when installing the package through a OS package manager

Changes proposed in this pull request:

* Installation of the locales within the package installation

