### PR TITLE
GHA: Temporarily toxlessly test PyPy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,9 +56,20 @@ jobs:
           python -m pip install --upgrade tox
 
       - name: Tox tests
+        if: matrix.python-version != 'pypy3'
         shell: bash
         run: |
           tox -e py
+
+        # Temporarily test PyPy3 without tox:
+        # https://foss.heptapod.net/pypy/pypy/-/issues/3331
+        # https://github.com/tox-dev/tox/issues/1704
+      - name: Non-tox tests (PyPy3)
+        if: matrix.python-version == 'pypy3'
+        shell: bash
+        run: |
+          python -m pip install ".[tests]"
+          python -m pytest --cov humanize --cov tests --cov-report xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
Temporarily test PyPy3 without tox due to a PyPy3 7.3.2 bug:

* https://foss.heptapod.net/pypy/pypy/-/issues/3331
* https://github.com/tox-dev/tox/issues/1704
