### PR TITLE
Revert "GHA: Temporarily toxlessly test PyPy"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,20 +46,9 @@ jobs:
           python -m pip install --upgrade tox
 
       - name: Tox tests
-        if: matrix.python-version != 'pypy3'
         shell: bash
         run: |
           tox -e py
-
-        # Temporarily test PyPy3 without tox:
-        # https://foss.heptapod.net/pypy/pypy/-/issues/3331
-        # https://github.com/tox-dev/tox/issues/1704
-      - name: Non-tox tests (PyPy3)
-        if: matrix.python-version == 'pypy3'
-        shell: bash
-        run: |
-          python -m pip install ".[tests]"
-          python -m pytest --cov humanize --cov tests --cov-report xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
Reverts jmoiron/humanize#174

GHA now has PyPy 7.3.3 and we can test it on Windows with tox: https://github.com/actions/setup-python/issues/163#issuecomment-739907048
