### PR TITLE
Adds the ability for intword to use user provided mapping. 

### DIFF
--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -161,13 +161,13 @@ def intword(value, format="%.1f", conversions=None):
         '1.234 million'
         >>> intword(100_000, "%0.0f", conversions=[(3, "K")])
         '100 K'
-        
+
         ```
     Args:
         value (int, float, str): Integer to convert.
         format (str): To change the number of decimal or general format of the number
             portion.
-        conversions [(int, str)]: Power to suffix conversion 
+        conversions [(int, str)]: Power to suffix conversion
 
     Returns:
         str: Friendly text representation as a string, unless the value passed could not


### PR DESCRIPTION
Adds the ability for intword to use user provided mapping.

Also fixes a bug where not conversions would be made if only one mapping is provided.

I was looking for the ability to humanize into "thousands" in addition to "millions", etc. and noticed it wasn't possible. 

This [StackOverflow](https://stackoverflow.com/a/30338484) comment lead me to expand intword. 

I also saw issues like #160, which lead me to believe I wouldn't be the only one to benefit from this. 

Changes proposed in this pull request:

* Changes `powers` and `human_powers` to be defined from a list of pairs 
* Fixes an edge case where conversions wouldn't happen if only one `(power, human_power)` pair is passed to `intword`
* Replaces `powers` and `human_powers` with `l_powers` and `l_human_powers` to avoid scope conflicts
* `intword` can receive a list of `(power, human_power)` pairs when called, to enable custom configurations.

If no custom configurations are passed, then it defaults to the existing ones. 

For example:

```python
import humanize

conversions = [
    (3, "K"),
    (6, "M"),
    (9, "B"),
    (12, "T"),
]


for power in range(0, 10):
	x = 10**power
	print(f"{x:>10} -> {humanize.intword(x, '%.0f', conversions=conversions):>5}")
```

outputs
```python
         1 ->     1
        10 ->    10
       100 ->   100
      1000 ->   1 K
     10000 ->  10 K
    100000 -> 100 K
   1000000 ->   1 M
  10000000 ->  10 M
 100000000 -> 100 M
1000000000 ->   1 B
```

This lets users expand conversions as needed (eg "thousand") or use custom abbreviations (eg, "k", "MM").