### PR TITLE
Fix tests for Python 3.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.4
+    rev: v2.12.0
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
@@ -12,23 +12,23 @@ repos:
         args: ["--target-version", "py36"]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.6.4
+    rev: 5.8.0
     hooks:
       - id: isort
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.0
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.7.0
+    rev: v1.8.0
     hooks:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict
       - id: check-toml
@@ -36,7 +36,7 @@ repos:
       - id: end-of-file-fixer
 
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 5.1.1
+    rev: 6.0.0
     hooks:
       - id: pydocstyle
         args: ["--convention", "google"]
@@ -48,6 +48,6 @@ repos:
       - id: tox-ini-fmt
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.15.1
+    rev: v1.17.0
     hooks:
     -   id: setup-cfg-fmt

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,14 +40,14 @@ include_package_data = True
 package_dir = =src
 zip_safe = False
 
+[options.packages.find]
+where = src
+
 [options.extras_require]
 tests =
     freezegun
     pytest
     pytest-cov
-
-[options.packages.find]
-where = src
 
 [flake8]
 max_line_length = 88

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -335,17 +335,17 @@ def _suitable_minimum_unit(min_unit, suppress):
     If not suppressed, return the same unit:
 
     >>> from humanize.time import _suitable_minimum_unit, Unit
-    >>> _suitable_minimum_unit(Unit.HOURS, [])
-    <Unit.HOURS: 4>
+    >>> _suitable_minimum_unit(Unit.HOURS, []).name
+    'HOURS'
 
     But if suppressed, find a unit greather than the original one that is not
     suppressed:
 
-    >>> _suitable_minimum_unit(Unit.HOURS, [Unit.HOURS])
-    <Unit.DAYS: 5>
+    >>> _suitable_minimum_unit(Unit.HOURS, [Unit.HOURS]).name
+    'DAYS'
 
-    >>> _suitable_minimum_unit(Unit.HOURS, [Unit.HOURS, Unit.DAYS])
-    <Unit.MONTHS: 6>
+    >>> _suitable_minimum_unit(Unit.HOURS, [Unit.HOURS, Unit.DAYS]).name
+    'MONTHS'
     """
     if min_unit in suppress:
         for unit in Unit:
@@ -363,8 +363,8 @@ def _suppress_lower_units(min_unit, suppress):
     """Extend suppressed units (if any) with all units lower than the minimum unit.
 
     >>> from humanize.time import _suppress_lower_units, Unit
-    >>> list(sorted(_suppress_lower_units(Unit.SECONDS, [Unit.DAYS])))
-    [<Unit.MICROSECONDS: 0>, <Unit.MILLISECONDS: 1>, <Unit.DAYS: 5>]
+    >>> [x.name for x in sorted(_suppress_lower_units(Unit.SECONDS, [Unit.DAYS]))]
+    ['MICROSECONDS', 'MILLISECONDS', 'DAYS']
     """
     suppress = set(suppress)
     for u in Unit:


### PR DESCRIPTION
Fixes #194.

Changes proposed in this pull request:

* `enum`'s `__repr__()` and `__str__()` are changing in 3.10, so use `.name` for the doctests
* https://docs.python.org/3.10/whatsnew/3.10.html#enum

```pycon
Python 3.9.4 (v3.9.4:1f2e3088f3, Apr  4 2021, 12:32:44)
[Clang 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from humanize.time import Unit
>>> repr(Unit.HOURS), str(Unit.HOURS), Unit.HOURS.name
('<Unit.HOURS: 4>', 'Unit.HOURS', 'HOURS')
>>>
```
```pycon
Python 3.10.0a7+ (heads/master:ea9b2d6, Apr 10 2021, 19:11:52) [Clang 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from humanize.time import Unit
>>> repr(Unit.HOURS), str(Unit.HOURS), Unit.HOURS.name
('Unit.HOURS', 'HOURS', 'HOURS')
>>>
```



* Also update pre-commit

