### PR TITLE
Add pluralization for intword

### DIFF
--- a/scripts/update-translations.sh
+++ b/scripts/update-translations.sh
@@ -1,7 +1,7 @@
 set -e
 
 # extract new phrases
-/usr/local/opt/gettext/bin/xgettext --from-code=UTF-8 -o humanize.pot -k'_' -k'N_' -k'P_:1c,2' -l python src/humanize/*.py
+/usr/local/opt/gettext/bin/xgettext --from-code=UTF-8 -o humanize.pot -k'_' -k'N_' -k'P_:1c,2' -k'NS_:1,2' -l python src/humanize/*.py
 
 for d in src/humanize/locale/*/; do
     locale="$(basename $d)"

--- a/src/humanize/i18n.py
+++ b/src/humanize/i18n.py
@@ -137,6 +137,26 @@ def gettext_noop(message):
     return message
 
 
+def ngettext_noop(singular, plural):
+    """Mark two strings as pluralized translations without translating them.
+
+    Example usage:
+    ```python
+    CONSTANTS = [ngettext_noop('first', 'firsts'), ngettext_noop('second', 'seconds')]
+    def num_name(n):
+        return ngettext(*CONSTANTS[n])
+    ```
+
+    Args:
+        singular (str): Singular text to translate in the future.
+        plural (str): Plural text to translate in the future.
+
+    Returns:
+        tuple: Original text, unchanged.
+    """
+    return (singular, plural)
+
+
 def thousands_separator() -> str:
     """Return the thousands separator for a locale, default to comma.
 

--- a/src/humanize/locale/ca_ES/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/ca_ES/LC_MESSAGES/humanize.po
@@ -74,77 +74,66 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/humanize/number.py:127
-#, fuzzy
 msgid "million"
 msgid_plural "million"
 msgstr[0] "milió"
 msgstr[1] "milió"
 
 #: src/humanize/number.py:128
-#, fuzzy
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "mil milions"
 msgstr[1] "mil milions"
 
 #: src/humanize/number.py:129
-#, fuzzy
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "bilions"
 msgstr[1] "bilions"
 
 #: src/humanize/number.py:130
-#, fuzzy
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "quadrilió"
 msgstr[1] "quadrilió"
 
 #: src/humanize/number.py:131
-#, fuzzy
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "quintillió"
 msgstr[1] "quintillió"
 
 #: src/humanize/number.py:132
-#, fuzzy
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "sextilió"
 msgstr[1] "sextilió"
 
 #: src/humanize/number.py:133
-#, fuzzy
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "septilió"
 msgstr[1] "septilió"
 
 #: src/humanize/number.py:134
-#, fuzzy
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "octilió"
 msgstr[1] "octilió"
 
 #: src/humanize/number.py:135
-#, fuzzy
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "nonilió"
 msgstr[1] "nonilió"
 
 #: src/humanize/number.py:136
-#, fuzzy
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "decilió"
 msgstr[1] "decilió"
 
 #: src/humanize/number.py:137
-#, fuzzy
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googol"

--- a/src/humanize/locale/ca_ES/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/ca_ES/LC_MESSAGES/humanize.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2021-04-09 19:57+0200\n"
 "Last-Translator: Jordi Mas i Hernàndez <jmas@softcatala.org>\n"
 "Language-Team: Catalan\n"
@@ -17,141 +17,176 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n!=1;\n"
 "X-Generator: Poedit 2.4.1\n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 msgctxt "0"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 msgctxt "1"
 msgid "st"
 msgstr "º"
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 msgctxt "2"
 msgid "nd"
 msgstr "º"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 msgctxt "3"
 msgid "rd"
 msgstr "º"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 msgctxt "4"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 msgctxt "5"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 msgctxt "6"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 msgctxt "7"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 msgctxt "8"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 msgctxt "9"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "milió"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "mil milions"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/humanize/number.py:127
-msgid "trillion"
-msgstr "bilions"
+#, fuzzy
+msgid "million"
+msgid_plural "million"
+msgstr[0] "milió"
+msgstr[1] "milió"
 
 #: src/humanize/number.py:128
-msgid "quadrillion"
-msgstr "quadrilió"
+#, fuzzy
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "mil milions"
+msgstr[1] "mil milions"
 
 #: src/humanize/number.py:129
-msgid "quintillion"
-msgstr "quintillió"
+#, fuzzy
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "bilions"
+msgstr[1] "bilions"
 
 #: src/humanize/number.py:130
-msgid "sextillion"
-msgstr "sextilió"
+#, fuzzy
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "quadrilió"
+msgstr[1] "quadrilió"
 
 #: src/humanize/number.py:131
-msgid "septillion"
-msgstr "septilió"
+#, fuzzy
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "quintillió"
+msgstr[1] "quintillió"
 
 #: src/humanize/number.py:132
-msgid "octillion"
-msgstr "octilió"
+#, fuzzy
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "sextilió"
+msgstr[1] "sextilió"
 
 #: src/humanize/number.py:133
-msgid "nonillion"
-msgstr "nonilió"
+#, fuzzy
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "septilió"
+msgstr[1] "septilió"
 
 #: src/humanize/number.py:134
-msgid "decillion"
-msgstr "decilió"
+#, fuzzy
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "octilió"
+msgstr[1] "octilió"
 
 #: src/humanize/number.py:135
-msgid "googol"
-msgstr "googol"
+#, fuzzy
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "nonilió"
+msgstr[1] "nonilió"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+#, fuzzy
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "decilió"
+msgstr[1] "decilió"
+
+#: src/humanize/number.py:137
+#, fuzzy
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "googol"
+msgstr[1] "googol"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr "zero"
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "un"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "dos"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "tres"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "quatre"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "cinc"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "sis"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "set"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "vuit"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "nou"
 

--- a/src/humanize/locale/de_DE/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/de_DE/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2016-12-18 11:50+0100\n"
 "Last-Translator: Christian Klein <chris@5711.org>\n"
 "Language-Team: German\n"
@@ -19,141 +19,165 @@ msgstr ""
 "Generated-By: Christian Klein\n"
 "X-Generator: Sublime Text 3\n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 msgctxt "0"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 msgctxt "1"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 msgctxt "2"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 msgctxt "3"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 msgctxt "4"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 msgctxt "5"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 msgctxt "6"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 msgctxt "7"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 msgctxt "8"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 msgctxt "9"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "Million"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "Milliarde"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/humanize/number.py:127
-msgid "trillion"
-msgstr "Billion"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "Million"
+msgstr[1] "Million"
 
 #: src/humanize/number.py:128
-msgid "quadrillion"
-msgstr "Billiarde"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "Milliarde"
+msgstr[1] "Milliarde"
 
 #: src/humanize/number.py:129
-msgid "quintillion"
-msgstr "Trillion"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "Billion"
+msgstr[1] "Billion"
 
 #: src/humanize/number.py:130
-msgid "sextillion"
-msgstr "Trilliarde"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "Billiarde"
+msgstr[1] "Billiarde"
 
 #: src/humanize/number.py:131
-msgid "septillion"
-msgstr "Quadrillion"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "Trillion"
+msgstr[1] "Trillion"
 
 #: src/humanize/number.py:132
-msgid "octillion"
-msgstr "Quadrillarde"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "Trilliarde"
+msgstr[1] "Trilliarde"
 
 #: src/humanize/number.py:133
-msgid "nonillion"
-msgstr "Quintillion"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "Quadrillion"
+msgstr[1] "Quadrillion"
 
 #: src/humanize/number.py:134
-msgid "decillion"
-msgstr "Quintilliarde"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "Quadrillarde"
+msgstr[1] "Quadrillarde"
 
 #: src/humanize/number.py:135
-msgid "googol"
-msgstr "Googol"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "Quintillion"
+msgstr[1] "Quintillion"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "Quintilliarde"
+msgstr[1] "Quintilliarde"
+
+#: src/humanize/number.py:137
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "Googol"
+msgstr[1] "Googol"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr "null"
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "eins"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "zwei"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "drei"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "vier"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "fünf"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "sechs"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "sieben"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "acht"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "neun"
 

--- a/src/humanize/locale/es_ES/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/es_ES/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2020-03-31 21:08+0200\n"
 "Last-Translator: Álvaro Mondéjar <mondejar1994@gmail.com>\n"
 "Language-Team: \n"
@@ -18,141 +18,165 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 msgctxt "0"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 msgctxt "1"
 msgid "st"
 msgstr "º"
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 msgctxt "2"
 msgid "nd"
 msgstr "º"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 msgctxt "3"
 msgid "rd"
 msgstr "º"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 msgctxt "4"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 msgctxt "5"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 msgctxt "6"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 msgctxt "7"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 msgctxt "8"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 msgctxt "9"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "millón"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "billón"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] "mil"
+msgstr[1] "mil"
 
 #: src/humanize/number.py:127
-msgid "trillion"
-msgstr "trillón"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "millón"
+msgstr[1] "millones"
 
 #: src/humanize/number.py:128
-msgid "quadrillion"
-msgstr "quatrillón"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "billón"
+msgstr[1] "billones"
 
 #: src/humanize/number.py:129
-msgid "quintillion"
-msgstr "quintillón"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "trillón"
+msgstr[1] "trillones"
 
 #: src/humanize/number.py:130
-msgid "sextillion"
-msgstr "sextillón"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "quatrillón"
+msgstr[1] "quatrillones"
 
 #: src/humanize/number.py:131
-msgid "septillion"
-msgstr "septillón"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "quintillón"
+msgstr[1] "quintillones"
 
 #: src/humanize/number.py:132
-msgid "octillion"
-msgstr "octillón"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "sextillón"
+msgstr[1] "sextillones"
 
 #: src/humanize/number.py:133
-msgid "nonillion"
-msgstr "nonillón"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "septillón"
+msgstr[1] "septillones"
 
 #: src/humanize/number.py:134
-msgid "decillion"
-msgstr "decillón"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "octillón"
+msgstr[1] "octillones"
 
 #: src/humanize/number.py:135
-msgid "googol"
-msgstr "gúgol"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "nonillón"
+msgstr[1] "nonillones"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "decillón"
+msgstr[1] "decillones"
+
+#: src/humanize/number.py:137
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "gúgol"
+msgstr[1] "gúgol"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr "cero"
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "uno"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "dos"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "tres"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "cuatro"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "cinco"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "seis"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "siete"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "ocho"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "nueve"
 

--- a/src/humanize/locale/fa_IR/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/fa_IR/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2017-01-10 02:44+0330\n"
 "Last-Translator: Christian Klein <chris@5711.org>\n"
 "Language-Team: German\n"
@@ -19,141 +19,165 @@ msgstr ""
 "Generated-By: Christian Klein\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 msgctxt "0"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 msgctxt "1"
 msgid "st"
 msgstr "اولین"
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 msgctxt "2"
 msgid "nd"
 msgstr "دومین"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 msgctxt "3"
 msgid "rd"
 msgstr "سومین"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 msgctxt "4"
 msgid "th"
 msgstr "چهارمین"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 msgctxt "5"
 msgid "th"
 msgstr "پنجمین"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 msgctxt "6"
 msgid "th"
 msgstr "ششمین"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 msgctxt "7"
 msgid "th"
 msgstr "هفتمین"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 msgctxt "8"
 msgid "th"
 msgstr "هشتمین"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 msgctxt "9"
 msgid "th"
 msgstr "نهمین"
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "میلیون"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "میلیارد"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/humanize/number.py:127
-msgid "trillion"
-msgstr "ترلیون"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "میلیون"
+msgstr[1] "میلیون"
 
 #: src/humanize/number.py:128
-msgid "quadrillion"
-msgstr "کوادریلیون"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "میلیارد"
+msgstr[1] "میلیارد"
 
 #: src/humanize/number.py:129
-msgid "quintillion"
-msgstr "کوانتیلیون"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "ترلیون"
+msgstr[1] "ترلیون"
 
 #: src/humanize/number.py:130
-msgid "sextillion"
-msgstr "سکستیلیون"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "کوادریلیون"
+msgstr[1] "کوادریلیون"
 
 #: src/humanize/number.py:131
-msgid "septillion"
-msgstr "سپتیلیون"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "کوانتیلیون"
+msgstr[1] "کوانتیلیون"
 
 #: src/humanize/number.py:132
-msgid "octillion"
-msgstr "اوکتیلیون"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "سکستیلیون"
+msgstr[1] "سکستیلیون"
 
 #: src/humanize/number.py:133
-msgid "nonillion"
-msgstr "نونیلیون"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "سپتیلیون"
+msgstr[1] "سپتیلیون"
 
 #: src/humanize/number.py:134
-msgid "decillion"
-msgstr "دسیلیون"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "اوکتیلیون"
+msgstr[1] "اوکتیلیون"
 
 #: src/humanize/number.py:135
-msgid "googol"
-msgstr "گوگول"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "نونیلیون"
+msgstr[1] "نونیلیون"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "دسیلیون"
+msgstr[1] "دسیلیون"
+
+#: src/humanize/number.py:137
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "گوگول"
+msgstr[1] "گوگول"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr ""
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "یک"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "دو"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "سه"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "چهار"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "پنج"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "شش"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "هفت"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "هشت"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "نه"
 

--- a/src/humanize/locale/fi_FI/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/fi_FI/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2017-03-02 11:26+0200\n"
 "Last-Translator: Ville Skyttä <ville.skytta@iki.fi>\n"
 "Language-Team: Finnish\n"
@@ -18,141 +18,165 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.12\n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 msgctxt "0"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 msgctxt "1"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 msgctxt "2"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 msgctxt "3"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 msgctxt "4"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 msgctxt "5"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 msgctxt "6"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 msgctxt "7"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 msgctxt "8"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 msgctxt "9"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr "tuhatta"
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "miljoonaa"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "miljardia"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] "tuhatta"
+msgstr[1] "tuhatta"
 
 #: src/humanize/number.py:127
-msgid "trillion"
-msgstr "biljoonaa"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "miljoonaa"
+msgstr[1] "miljoonaa"
 
 #: src/humanize/number.py:128
-msgid "quadrillion"
-msgstr "kvadriljoonaa"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "miljardia"
+msgstr[1] "miljardia"
 
 #: src/humanize/number.py:129
-msgid "quintillion"
-msgstr "kvintiljoonaa"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "biljoonaa"
+msgstr[1] "biljoonaa"
 
 #: src/humanize/number.py:130
-msgid "sextillion"
-msgstr "sekstiljoonaa"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "kvadriljoonaa"
+msgstr[1] "kvadriljoonaa"
 
 #: src/humanize/number.py:131
-msgid "septillion"
-msgstr "septiljoonaa"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "kvintiljoonaa"
+msgstr[1] "kvintiljoonaa"
 
 #: src/humanize/number.py:132
-msgid "octillion"
-msgstr "oktiljoonaa"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "sekstiljoonaa"
+msgstr[1] "sekstiljoonaa"
 
 #: src/humanize/number.py:133
-msgid "nonillion"
-msgstr "noniljoonaa"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "septiljoonaa"
+msgstr[1] "septiljoonaa"
 
 #: src/humanize/number.py:134
-msgid "decillion"
-msgstr "dekiljoonaa"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "oktiljoonaa"
+msgstr[1] "oktiljoonaa"
 
 #: src/humanize/number.py:135
-msgid "googol"
-msgstr "googol"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "noniljoonaa"
+msgstr[1] "noniljoonaa"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "dekiljoonaa"
+msgstr[1] "dekiljoonaa"
+
+#: src/humanize/number.py:137
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "googol"
+msgstr[1] "googol"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr "nolla"
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "yksi"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "kaksi"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "kolme"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "neljä"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "viisi"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "kuusi"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "seitsemän"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "kahdeksan"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "yhdeksän"
 

--- a/src/humanize/locale/fr_FR/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/fr_FR/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2013-06-22 08:52+0100\n"
 "Last-Translator: Olivier Cortès <oc@1flow.io>\n"
 "Language-Team: fr_FR <LL@li.org>\n"
@@ -19,161 +19,185 @@ msgstr ""
 "Generated-By: Babel 0.9.6\n"
 "X-Generator: Poedit 1.5.5\n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 #, fuzzy
 msgctxt "0"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 #, fuzzy
 msgctxt "1"
 msgid "st"
 msgstr "er"
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 #, fuzzy
 msgctxt "2"
 msgid "nd"
 msgstr "e"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 #, fuzzy
 msgctxt "3"
 msgid "rd"
 msgstr "e"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 #, fuzzy
 msgctxt "4"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 #, fuzzy
 msgctxt "5"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 #, fuzzy
 msgctxt "6"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 #, fuzzy
 msgctxt "7"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 #, fuzzy
 msgctxt "8"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 #, fuzzy
 msgctxt "9"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-#, fuzzy
-msgid "million"
-msgstr "%(value)s million"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "milliard"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/humanize/number.py:127
 #, fuzzy
-msgid "trillion"
-msgstr "%(value)s billion"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "%(value)s million"
+msgstr[1] "%(value)s million"
 
 #: src/humanize/number.py:128
-#, fuzzy
-msgid "quadrillion"
-msgstr "%(value)s billiard"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "milliard"
+msgstr[1] "milliard"
 
 #: src/humanize/number.py:129
 #, fuzzy
-msgid "quintillion"
-msgstr "%(value)s trillion"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "%(value)s billion"
+msgstr[1] "%(value)s billion"
 
 #: src/humanize/number.py:130
 #, fuzzy
-msgid "sextillion"
-msgstr "%(value)s trilliard"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "%(value)s billiard"
+msgstr[1] "%(value)s billiard"
 
 #: src/humanize/number.py:131
 #, fuzzy
-msgid "septillion"
-msgstr "%(value)s quatrillion"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "%(value)s trillion"
+msgstr[1] "%(value)s trillion"
 
 #: src/humanize/number.py:132
 #, fuzzy
-msgid "octillion"
-msgstr "%(value)s quadrilliard"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "%(value)s trilliard"
+msgstr[1] "%(value)s trilliard"
 
 #: src/humanize/number.py:133
 #, fuzzy
-msgid "nonillion"
-msgstr "%(value)s quintillion"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "%(value)s quatrillion"
+msgstr[1] "%(value)s quatrillion"
 
 #: src/humanize/number.py:134
 #, fuzzy
-msgid "decillion"
-msgstr "%(value)s quintilliard"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "%(value)s quadrilliard"
+msgstr[1] "%(value)s quadrilliard"
 
 #: src/humanize/number.py:135
 #, fuzzy
-msgid "googol"
-msgstr "%(value)s gogol"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "%(value)s quintillion"
+msgstr[1] "%(value)s quintillion"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+#, fuzzy
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "%(value)s quintilliard"
+msgstr[1] "%(value)s quintilliard"
+
+#: src/humanize/number.py:137
+#, fuzzy
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "%(value)s gogol"
+msgstr[1] "%(value)s gogol"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr "zéro"
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "un"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "deux"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "trois"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "quatre"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "cinq"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "six"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "sept"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "huit"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "neuf"
 

--- a/src/humanize/locale/id_ID/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/id_ID/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2017-03-18 15:41+0700\n"
 "Last-Translator: adie.rebel@gmail.com\n"
 "Language-Team: Indonesian\n"
@@ -18,141 +18,153 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 1.8.11\n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 msgctxt "0"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 msgctxt "1"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 msgctxt "2"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 msgctxt "3"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 msgctxt "4"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 msgctxt "5"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 msgctxt "6"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 msgctxt "7"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 msgctxt "8"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 msgctxt "9"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "juta"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "miliar"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
 
 #: src/humanize/number.py:127
-msgid "trillion"
-msgstr "triliun"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "juta"
 
 #: src/humanize/number.py:128
-msgid "quadrillion"
-msgstr "kuadriliun"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "miliar"
 
 #: src/humanize/number.py:129
-msgid "quintillion"
-msgstr "quintillion"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "triliun"
 
 #: src/humanize/number.py:130
-msgid "sextillion"
-msgstr "sextillion"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "kuadriliun"
 
 #: src/humanize/number.py:131
-msgid "septillion"
-msgstr "septillion"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "quintillion"
 
 #: src/humanize/number.py:132
-msgid "octillion"
-msgstr "octillion"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "sextillion"
 
 #: src/humanize/number.py:133
-msgid "nonillion"
-msgstr "nonillion"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "septillion"
 
 #: src/humanize/number.py:134
-msgid "decillion"
-msgstr "decillion"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "octillion"
 
 #: src/humanize/number.py:135
-msgid "googol"
-msgstr "googol"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "nonillion"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "decillion"
+
+#: src/humanize/number.py:137
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "googol"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr "nol"
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "satu"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "dua"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "tiga"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "empat"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "lima"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "enam"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "tujuh"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "delapan"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "sembilan"
 

--- a/src/humanize/locale/it_IT/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/it_IT/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2018-10-27 22:52+0200\n"
 "Last-Translator: derfel <code@derfel.net>\n"
 "Language-Team: Italian\n"
@@ -18,141 +18,165 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.2\n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 msgctxt "0"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 msgctxt "1"
 msgid "st"
 msgstr "º"
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 msgctxt "2"
 msgid "nd"
 msgstr "º"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 msgctxt "3"
 msgid "rd"
 msgstr "º"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 msgctxt "4"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 msgctxt "5"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 msgctxt "6"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 msgctxt "7"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 msgctxt "8"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 msgctxt "9"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "milioni"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "miliardi"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/humanize/number.py:127
-msgid "trillion"
-msgstr "bilioni"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "milioni"
+msgstr[1] "milioni"
 
 #: src/humanize/number.py:128
-msgid "quadrillion"
-msgstr "biliardi"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "miliardi"
+msgstr[1] "miliardi"
 
 #: src/humanize/number.py:129
-msgid "quintillion"
-msgstr "trilioni"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "bilioni"
+msgstr[1] "bilioni"
 
 #: src/humanize/number.py:130
-msgid "sextillion"
-msgstr "triliardi"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "biliardi"
+msgstr[1] "biliardi"
 
 #: src/humanize/number.py:131
-msgid "septillion"
-msgstr "quadrilioni"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "trilioni"
+msgstr[1] "trilioni"
 
 #: src/humanize/number.py:132
-msgid "octillion"
-msgstr "quadriliardi"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "triliardi"
+msgstr[1] "triliardi"
 
 #: src/humanize/number.py:133
-msgid "nonillion"
-msgstr "quintilioni"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "quadrilioni"
+msgstr[1] "quadrilioni"
 
 #: src/humanize/number.py:134
-msgid "decillion"
-msgstr "quintiliardi"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "quadriliardi"
+msgstr[1] "quadriliardi"
 
 #: src/humanize/number.py:135
-msgid "googol"
-msgstr "googol"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "quintilioni"
+msgstr[1] "quintilioni"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "quintiliardi"
+msgstr[1] "quintiliardi"
+
+#: src/humanize/number.py:137
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "googol"
+msgstr[1] "googol"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr "zero"
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "uno"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "due"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "tre"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "quattro"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "cinque"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "sei"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "sette"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "otto"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "nove"
 

--- a/src/humanize/locale/ja_JP/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/ja_JP/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2018-01-22 10:48+0900\n"
 "Last-Translator: Kan Torii <oss@qoolloop.com>\n"
 "Language-Team: Japanese\n"
@@ -19,150 +19,162 @@ msgstr ""
 "Generated-By: Babel 0.9.6\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 msgctxt "0"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 msgctxt "1"
 msgid "st"
 msgstr "番目"
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 msgctxt "2"
 msgid "nd"
 msgstr "番目"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 msgctxt "3"
 msgid "rd"
 msgstr "番目"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 msgctxt "4"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 msgctxt "5"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 msgctxt "6"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 msgctxt "7"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 msgctxt "8"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 msgctxt "9"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "百万"
-
 #: src/humanize/number.py:126
-#, fuzzy
-msgid "billion"
-msgstr "十億"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
 
 #: src/humanize/number.py:127
-msgid "trillion"
-msgstr "兆"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "百万"
 
 #: src/humanize/number.py:128
 #, fuzzy
-msgid "quadrillion"
-msgstr "千兆"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "十億"
 
 #: src/humanize/number.py:129
-#, fuzzy
-msgid "quintillion"
-msgstr "百京"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "兆"
 
 #: src/humanize/number.py:130
 #, fuzzy
-msgid "sextillion"
-msgstr "十垓"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "千兆"
 
 #: src/humanize/number.py:131
 #, fuzzy
-msgid "septillion"
-msgstr "じょ"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "百京"
 
 #: src/humanize/number.py:132
 #, fuzzy
-msgid "octillion"
-msgstr "千じょ"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "十垓"
 
 #: src/humanize/number.py:133
 #, fuzzy
-msgid "nonillion"
-msgstr "百穣"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "じょ"
 
 #: src/humanize/number.py:134
 #, fuzzy
-msgid "decillion"
-msgstr "十溝"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "千じょ"
 
 #: src/humanize/number.py:135
 #, fuzzy
-msgid "googol"
-msgstr "溝無量大数"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "百穣"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+#, fuzzy
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "十溝"
+
+#: src/humanize/number.py:137
+#, fuzzy
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "溝無量大数"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr ""
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "一"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "二"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "三"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "四"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "五"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "六"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "七"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "八"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "九"
 

--- a/src/humanize/locale/ko_KR/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/ko_KR/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2013-07-10 11:38+0900\n"
 "Last-Translator: @youngrok\n"
 "Language-Team: ko_KR <LL@li.org>\n"
@@ -19,160 +19,184 @@ msgstr ""
 "Generated-By: Babel 0.9.6\n"
 "X-Generator: Poedit 1.5.7\n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 #, fuzzy
 msgctxt "0"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 #, fuzzy
 msgctxt "1"
 msgid "st"
 msgstr "번째"
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 #, fuzzy
 msgctxt "2"
 msgid "nd"
 msgstr "번째"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 #, fuzzy
 msgctxt "3"
 msgid "rd"
 msgstr "번째"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 #, fuzzy
 msgctxt "4"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 #, fuzzy
 msgctxt "5"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 #, fuzzy
 msgctxt "6"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 #, fuzzy
 msgctxt "7"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 #, fuzzy
 msgctxt "8"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 #, fuzzy
 msgctxt "9"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "%(value)s million"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "milliard"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/humanize/number.py:127
-#, fuzzy
-msgid "trillion"
-msgstr "%(value)s billion"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "%(value)s million"
+msgstr[1] "%(value)s million"
 
 #: src/humanize/number.py:128
-#, fuzzy
-msgid "quadrillion"
-msgstr "%(value)s quadrillion"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "milliard"
+msgstr[1] "milliard"
 
 #: src/humanize/number.py:129
 #, fuzzy
-msgid "quintillion"
-msgstr "%(value)s quintillion"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "%(value)s billion"
+msgstr[1] "%(value)s billion"
 
 #: src/humanize/number.py:130
 #, fuzzy
-msgid "sextillion"
-msgstr "%(value)s sextillion"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "%(value)s quadrillion"
+msgstr[1] "%(value)s quadrillion"
 
 #: src/humanize/number.py:131
 #, fuzzy
-msgid "septillion"
-msgstr "%(value)s septillion"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "%(value)s quintillion"
+msgstr[1] "%(value)s quintillion"
 
 #: src/humanize/number.py:132
 #, fuzzy
-msgid "octillion"
-msgstr "%(value)s octillion"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "%(value)s sextillion"
+msgstr[1] "%(value)s sextillion"
 
 #: src/humanize/number.py:133
 #, fuzzy
-msgid "nonillion"
-msgstr "%(value)s nonillion"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "%(value)s septillion"
+msgstr[1] "%(value)s septillion"
 
 #: src/humanize/number.py:134
 #, fuzzy
-msgid "decillion"
-msgstr "%(value)s décillion"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "%(value)s octillion"
+msgstr[1] "%(value)s octillion"
 
 #: src/humanize/number.py:135
 #, fuzzy
-msgid "googol"
-msgstr "%(value)s gogol"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "%(value)s nonillion"
+msgstr[1] "%(value)s nonillion"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+#, fuzzy
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "%(value)s décillion"
+msgstr[1] "%(value)s décillion"
+
+#: src/humanize/number.py:137
+#, fuzzy
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "%(value)s gogol"
+msgstr[1] "%(value)s gogol"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr ""
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "하나"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "둘"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "셋"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "넷"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "다섯"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "여섯"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "일곱"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "여덟"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "아홉"
 

--- a/src/humanize/locale/nl_NL/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/nl_NL/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2015-03-25 21:08+0100\n"
 "Last-Translator: Martin van Wingerden\n"
 "Language-Team: nl_NL\n"
@@ -19,141 +19,165 @@ msgstr ""
 "Generated-By: Babel 0.9.6\n"
 "X-Generator: Poedit 1.7.5\n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 msgctxt "0"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 msgctxt "1"
 msgid "st"
 msgstr "ste"
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 msgctxt "2"
 msgid "nd"
 msgstr "de"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 msgctxt "3"
 msgid "rd"
 msgstr "de"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 msgctxt "4"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 msgctxt "5"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 msgctxt "6"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 msgctxt "7"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 msgctxt "8"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 msgctxt "9"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "miljoen"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "miljard"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/humanize/number.py:127
-msgid "trillion"
-msgstr "biljoen"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "miljoen"
+msgstr[1] "miljoen"
 
 #: src/humanize/number.py:128
-msgid "quadrillion"
-msgstr "biljard"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "miljard"
+msgstr[1] "miljard"
 
 #: src/humanize/number.py:129
-msgid "quintillion"
-msgstr "triljoen"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "biljoen"
+msgstr[1] "biljoen"
 
 #: src/humanize/number.py:130
-msgid "sextillion"
-msgstr "triljard"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "biljard"
+msgstr[1] "biljard"
 
 #: src/humanize/number.py:131
-msgid "septillion"
-msgstr "quadriljoen"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "triljoen"
+msgstr[1] "triljoen"
 
 #: src/humanize/number.py:132
-msgid "octillion"
-msgstr "quadriljard"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "triljard"
+msgstr[1] "triljard"
 
 #: src/humanize/number.py:133
-msgid "nonillion"
-msgstr "quintiljoen"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "quadriljoen"
+msgstr[1] "quadriljoen"
 
 #: src/humanize/number.py:134
-msgid "decillion"
-msgstr "quintiljard"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "quadriljard"
+msgstr[1] "quadriljard"
 
 #: src/humanize/number.py:135
-msgid "googol"
-msgstr "googol"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "quintiljoen"
+msgstr[1] "quintiljoen"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "quintiljard"
+msgstr[1] "quintiljard"
+
+#: src/humanize/number.py:137
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "googol"
+msgstr[1] "googol"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr "nul"
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "één"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "twee"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "drie"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "vier"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "vijf"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "zes"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "zeven"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "acht"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "negen"
 

--- a/src/humanize/locale/pl_PL/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/pl_PL/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2020-04-22 10:02+0200\n"
 "Last-Translator: Bartosz Bubak <bartosz.bubak gmail com>\n"
 "Language-Team: Polish\n"
@@ -18,141 +18,177 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 msgctxt "0"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 msgctxt "1"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 msgctxt "2"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 msgctxt "3"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 msgctxt "4"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 msgctxt "5"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 msgctxt "6"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 msgctxt "7"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 msgctxt "8"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 msgctxt "9"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "milion"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "bilion"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/humanize/number.py:127
-msgid "trillion"
-msgstr "trylion"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "milion"
+msgstr[1] "milion"
+msgstr[2] "milion"
 
 #: src/humanize/number.py:128
-msgid "quadrillion"
-msgstr "kwadrylion"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "bilion"
+msgstr[1] "bilion"
+msgstr[2] "bilion"
 
 #: src/humanize/number.py:129
-msgid "quintillion"
-msgstr "kwintylion"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "trylion"
+msgstr[1] "trylion"
+msgstr[2] "trylion"
 
 #: src/humanize/number.py:130
-msgid "sextillion"
-msgstr "sekstylion"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "kwadrylion"
+msgstr[1] "kwadrylion"
+msgstr[2] "kwadrylion"
 
 #: src/humanize/number.py:131
-msgid "septillion"
-msgstr "septylion"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "kwintylion"
+msgstr[1] "kwintylion"
+msgstr[2] "kwintylion"
 
 #: src/humanize/number.py:132
-msgid "octillion"
-msgstr "oktylion"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "sekstylion"
+msgstr[1] "sekstylion"
+msgstr[2] "sekstylion"
 
 #: src/humanize/number.py:133
-msgid "nonillion"
-msgstr "nonilion"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "septylion"
+msgstr[1] "septylion"
+msgstr[2] "septylion"
 
 #: src/humanize/number.py:134
-msgid "decillion"
-msgstr "decylion"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "oktylion"
+msgstr[1] "oktylion"
+msgstr[2] "oktylion"
 
 #: src/humanize/number.py:135
-msgid "googol"
-msgstr "googol"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "nonilion"
+msgstr[1] "nonilion"
+msgstr[2] "nonilion"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "decylion"
+msgstr[1] "decylion"
+msgstr[2] "decylion"
+
+#: src/humanize/number.py:137
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "googol"
+msgstr[1] "googol"
+msgstr[2] "googol"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr "zero"
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "jeden"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "dwa"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "trzy"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "cztery"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "pięć"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "sześć"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "siedem"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "osiem"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "dziewięć"
 

--- a/src/humanize/locale/pt_BR/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/pt_BR/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2016-06-15 15:58-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,141 +18,165 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 1.8.5\n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 msgctxt "0"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 msgctxt "1"
 msgid "st"
 msgstr "º"
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 msgctxt "2"
 msgid "nd"
 msgstr "º"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 msgctxt "3"
 msgid "rd"
 msgstr "º"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 msgctxt "4"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 msgctxt "5"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 msgctxt "6"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 msgctxt "7"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 msgctxt "8"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 msgctxt "9"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "milhão"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "bilhão"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/humanize/number.py:127
-msgid "trillion"
-msgstr "trilhão"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "milhão"
+msgstr[1] "milhão"
 
 #: src/humanize/number.py:128
-msgid "quadrillion"
-msgstr "quatrilhão"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "bilhão"
+msgstr[1] "bilhão"
 
 #: src/humanize/number.py:129
-msgid "quintillion"
-msgstr "quintilhão"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "trilhão"
+msgstr[1] "trilhão"
 
 #: src/humanize/number.py:130
-msgid "sextillion"
-msgstr "sextilhão"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "quatrilhão"
+msgstr[1] "quatrilhão"
 
 #: src/humanize/number.py:131
-msgid "septillion"
-msgstr "septilhão"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "quintilhão"
+msgstr[1] "quintilhão"
 
 #: src/humanize/number.py:132
-msgid "octillion"
-msgstr "octilhão"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "sextilhão"
+msgstr[1] "sextilhão"
 
 #: src/humanize/number.py:133
-msgid "nonillion"
-msgstr "nonilhão"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "septilhão"
+msgstr[1] "septilhão"
 
 #: src/humanize/number.py:134
-msgid "decillion"
-msgstr "decilhão"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "octilhão"
+msgstr[1] "octilhão"
 
 #: src/humanize/number.py:135
-msgid "googol"
-msgstr "undecilhão"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "nonilhão"
+msgstr[1] "nonilhão"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "decilhão"
+msgstr[1] "decilhão"
+
+#: src/humanize/number.py:137
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "undecilhão"
+msgstr[1] "undecilhão"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr "zero"
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "um"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "dois"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "três"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "quatro"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "cinco"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "seis"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "sete"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "oito"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "nove"
 

--- a/src/humanize/locale/pt_PT/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/pt_PT/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2020-07-05 18:17+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,141 +18,165 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.3.1\n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 msgctxt "0"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 msgctxt "1"
 msgid "st"
 msgstr "º"
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 msgctxt "2"
 msgid "nd"
 msgstr "º"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 msgctxt "3"
 msgid "rd"
 msgstr "º"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 msgctxt "4"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 msgctxt "5"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 msgctxt "6"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 msgctxt "7"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 msgctxt "8"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 msgctxt "9"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "milhão"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "milhar de milhão"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/humanize/number.py:127
-msgid "trillion"
-msgstr "bilião"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "milhão"
+msgstr[1] "milhão"
 
 #: src/humanize/number.py:128
-msgid "quadrillion"
-msgstr "mil biliões"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "milhar de milhão"
+msgstr[1] "milhar de milhão"
 
 #: src/humanize/number.py:129
-msgid "quintillion"
-msgstr "trilião"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "bilião"
+msgstr[1] "bilião"
 
 #: src/humanize/number.py:130
-msgid "sextillion"
-msgstr "mil triliões"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "mil biliões"
+msgstr[1] "mil biliões"
 
 #: src/humanize/number.py:131
-msgid "septillion"
-msgstr "quatrilião"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "trilião"
+msgstr[1] "trilião"
 
 #: src/humanize/number.py:132
-msgid "octillion"
-msgstr "mil quatriliões"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "mil triliões"
+msgstr[1] "mil triliões"
 
 #: src/humanize/number.py:133
-msgid "nonillion"
-msgstr "quintilhão"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "quatrilião"
+msgstr[1] "quatrilião"
 
 #: src/humanize/number.py:134
-msgid "decillion"
-msgstr "mil quintilhões"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "mil quatriliões"
+msgstr[1] "mil quatriliões"
 
 #: src/humanize/number.py:135
-msgid "googol"
-msgstr "sextilhão"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "quintilhão"
+msgstr[1] "quintilhão"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "mil quintilhões"
+msgstr[1] "mil quintilhões"
+
+#: src/humanize/number.py:137
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "sextilhão"
+msgstr[1] "sextilhão"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr "zero"
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "um"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "dois"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "três"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "quatro"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "cinco"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "seis"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "sete"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "oito"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "nove"
 

--- a/src/humanize/locale/ru_RU/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/ru_RU/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2014-03-24 20:32+0300\n"
 "Last-Translator: Sergey Prokhorov <me@seriyps.ru>\n"
 "Language-Team: ru_RU <LL@li.org>\n"
@@ -21,147 +21,183 @@ msgstr ""
 "X-Generator: Poedit 1.5.4\n"
 
 # в Django тут "ий" но на самом деле оба варианта работают плохо
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 msgctxt "0"
 msgid "th"
 msgstr "ой"
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 msgctxt "1"
 msgid "st"
 msgstr "ый"
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 msgctxt "2"
 msgid "nd"
 msgstr "ой"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 msgctxt "3"
 msgid "rd"
 msgstr "ий"
 
 # в Django тут "ий" но на самом деле оба варианта работают плохо
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 msgctxt "4"
 msgid "th"
 msgstr "ый"
 
 # в Django тут "ий" но на самом деле оба варианта работают плохо
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 msgctxt "5"
 msgid "th"
 msgstr "ый"
 
 # в Django тут "ий" но на самом деле оба варианта работают плохо
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 msgctxt "6"
 msgid "th"
 msgstr "ой"
 
 # в Django тут "ий" но на самом деле оба варианта работают плохо
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 msgctxt "7"
 msgid "th"
 msgstr "ой"
 
 # в Django тут "ий" но на самом деле оба варианта работают плохо
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 msgctxt "8"
 msgid "th"
 msgstr "ой"
 
 # в Django тут "ий" но на самом деле оба варианта работают плохо
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 msgctxt "9"
 msgid "th"
 msgstr "ый"
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "миллиона"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "миллиарда"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/humanize/number.py:127
-msgid "trillion"
-msgstr "триллиона"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "миллиона"
+msgstr[1] "миллиона"
+msgstr[2] "миллиона"
 
 #: src/humanize/number.py:128
-msgid "quadrillion"
-msgstr "квадриллиона"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "миллиарда"
+msgstr[1] "миллиарда"
+msgstr[2] "миллиарда"
 
 #: src/humanize/number.py:129
-msgid "quintillion"
-msgstr "квинтиллиона"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "триллиона"
+msgstr[1] "триллиона"
+msgstr[2] "триллиона"
 
 #: src/humanize/number.py:130
-msgid "sextillion"
-msgstr "сикстиллиона"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "квадриллиона"
+msgstr[1] "квадриллиона"
+msgstr[2] "квадриллиона"
 
 #: src/humanize/number.py:131
-msgid "septillion"
-msgstr "септиллиона"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "квинтиллиона"
+msgstr[1] "квинтиллиона"
+msgstr[2] "квинтиллиона"
 
 #: src/humanize/number.py:132
-msgid "octillion"
-msgstr "октиллиона"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "сикстиллиона"
+msgstr[1] "сикстиллиона"
+msgstr[2] "сикстиллиона"
 
 #: src/humanize/number.py:133
-msgid "nonillion"
-msgstr "нониллиона"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "септиллиона"
+msgstr[1] "септиллиона"
+msgstr[2] "септиллиона"
 
 #: src/humanize/number.py:134
-msgid "decillion"
-msgstr "децилиона"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "октиллиона"
+msgstr[1] "октиллиона"
+msgstr[2] "октиллиона"
 
 #: src/humanize/number.py:135
-msgid "googol"
-msgstr "гогола"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "нониллиона"
+msgstr[1] "нониллиона"
+msgstr[2] "нониллиона"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "децилиона"
+msgstr[1] "децилиона"
+msgstr[2] "децилиона"
+
+#: src/humanize/number.py:137
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "гогола"
+msgstr[1] "гогола"
+msgstr[2] "гогола"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr ""
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "один"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "два"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "три"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "четыре"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "пять"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "шесть"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "семь"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "восемь"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "девять"
 

--- a/src/humanize/locale/sk_SK/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/sk_SK/LC_MESSAGES/humanize.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2020-09-29 22:43+0300\n"
 "Last-Translator: Jose Riha <jose1711 gmail com>\n"
 "Language-Team: sk <LL@li.org>\n"
@@ -18,141 +18,177 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 msgctxt "0"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 msgctxt "1"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 msgctxt "2"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 msgctxt "3"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 msgctxt "4"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 msgctxt "5"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 msgctxt "6"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 msgctxt "7"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 msgctxt "8"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 msgctxt "9"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "milióna/ov"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "miliardy/árd"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/humanize/number.py:127
-msgid "trillion"
-msgstr "bilióna/ov"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "milióna/ov"
+msgstr[1] "milióna/ov"
+msgstr[2] "milióna/ov"
 
 #: src/humanize/number.py:128
-msgid "quadrillion"
-msgstr "biliardy/árd"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "miliardy/árd"
+msgstr[1] "miliardy/árd"
+msgstr[2] "miliardy/árd"
 
 #: src/humanize/number.py:129
-msgid "quintillion"
-msgstr "trilióna/árd"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "bilióna/ov"
+msgstr[1] "bilióna/ov"
+msgstr[2] "bilióna/ov"
 
 #: src/humanize/number.py:130
-msgid "sextillion"
-msgstr "triliardy/árd"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "biliardy/árd"
+msgstr[1] "biliardy/árd"
+msgstr[2] "biliardy/árd"
 
 #: src/humanize/number.py:131
-msgid "septillion"
-msgstr "kvadrilióna/ov"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "trilióna/árd"
+msgstr[1] "trilióna/árd"
+msgstr[2] "trilióna/árd"
 
 #: src/humanize/number.py:132
-msgid "octillion"
-msgstr "kvadriliardy/árd"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "triliardy/árd"
+msgstr[1] "triliardy/árd"
+msgstr[2] "triliardy/árd"
 
 #: src/humanize/number.py:133
-msgid "nonillion"
-msgstr "kvintilióna/ov"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "kvadrilióna/ov"
+msgstr[1] "kvadrilióna/ov"
+msgstr[2] "kvadrilióna/ov"
 
 #: src/humanize/number.py:134
-msgid "decillion"
-msgstr "kvintiliardy/árd"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "kvadriliardy/árd"
+msgstr[1] "kvadriliardy/árd"
+msgstr[2] "kvadriliardy/árd"
 
 #: src/humanize/number.py:135
-msgid "googol"
-msgstr "googola/ov"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "kvintilióna/ov"
+msgstr[1] "kvintilióna/ov"
+msgstr[2] "kvintilióna/ov"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "kvintiliardy/árd"
+msgstr[1] "kvintiliardy/árd"
+msgstr[2] "kvintiliardy/árd"
+
+#: src/humanize/number.py:137
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "googola/ov"
+msgstr[1] "googola/ov"
+msgstr[2] "googola/ov"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr "nula"
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "jedna"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "dve"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "tri"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "štyri"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "päť"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "šesť"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "sedem"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "osem"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "deväť"
 

--- a/src/humanize/locale/tr_TR/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/tr_TR/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2017-02-23 20:00+0300\n"
 "Last-Translator: Emre Çintay <emre@cintay.com>\n"
 "Language-Team: Turkish\n"
@@ -19,141 +19,165 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Generated-By: Emre Çintay\n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 msgctxt "0"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 msgctxt "1"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 msgctxt "2"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 msgctxt "3"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 msgctxt "4"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 msgctxt "5"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 msgctxt "6"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 msgctxt "7"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 msgctxt "8"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 msgctxt "9"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "milyon"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "milyar"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/humanize/number.py:127
-msgid "trillion"
-msgstr "trilyon"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "milyon"
+msgstr[1] "milyon"
 
 #: src/humanize/number.py:128
-msgid "quadrillion"
-msgstr "katrilyon"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "milyar"
+msgstr[1] "milyar"
 
 #: src/humanize/number.py:129
-msgid "quintillion"
-msgstr "kentilyon"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "trilyon"
+msgstr[1] "trilyon"
 
 #: src/humanize/number.py:130
-msgid "sextillion"
-msgstr "sekstilyon"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "katrilyon"
+msgstr[1] "katrilyon"
 
 #: src/humanize/number.py:131
-msgid "septillion"
-msgstr "septilyon"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "kentilyon"
+msgstr[1] "kentilyon"
 
 #: src/humanize/number.py:132
-msgid "octillion"
-msgstr "oktilyon"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "sekstilyon"
+msgstr[1] "sekstilyon"
 
 #: src/humanize/number.py:133
-msgid "nonillion"
-msgstr "nonilyon"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "septilyon"
+msgstr[1] "septilyon"
 
 #: src/humanize/number.py:134
-msgid "decillion"
-msgstr "desilyon"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "oktilyon"
+msgstr[1] "oktilyon"
 
 #: src/humanize/number.py:135
-msgid "googol"
-msgstr "googol"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "nonilyon"
+msgstr[1] "nonilyon"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "desilyon"
+msgstr[1] "desilyon"
+
+#: src/humanize/number.py:137
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "googol"
+msgstr[1] "googol"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr ""
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "bir"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "iki"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "üç"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "dört"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "beş"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "altı"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "yedi"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "sekiz"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "dokuz"
 

--- a/src/humanize/locale/uk_UA/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/uk_UA/LC_MESSAGES/humanize.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: TL\n"
 "Language-Team: uk_UA\n"
@@ -15,141 +15,177 @@ msgstr ""
 "Generated-By:\n"
 "X-Generator: \n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 msgctxt "0"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 msgctxt "1"
 msgid "st"
 msgstr "ий"
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 msgctxt "2"
 msgid "nd"
 msgstr "ий"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 msgctxt "3"
 msgid "rd"
 msgstr "ій"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 msgctxt "4"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 msgctxt "5"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 msgctxt "6"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 msgctxt "7"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 msgctxt "8"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 msgctxt "9"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "мільйонів"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "мільярдів"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/humanize/number.py:127
-msgid "trillion"
-msgstr "трильйонів"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "мільйонів"
+msgstr[1] "мільйонів"
+msgstr[2] "мільйонів"
 
 #: src/humanize/number.py:128
-msgid "quadrillion"
-msgstr "квадрильйонів"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "мільярдів"
+msgstr[1] "мільярдів"
+msgstr[2] "мільярдів"
 
 #: src/humanize/number.py:129
-msgid "quintillion"
-msgstr "квинтиліонів"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "трильйонів"
+msgstr[1] "трильйонів"
+msgstr[2] "трильйонів"
 
 #: src/humanize/number.py:130
-msgid "sextillion"
-msgstr "сикстильйонів"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "квадрильйонів"
+msgstr[1] "квадрильйонів"
+msgstr[2] "квадрильйонів"
 
 #: src/humanize/number.py:131
-msgid "septillion"
-msgstr "септильйонів"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "квинтиліонів"
+msgstr[1] "квинтиліонів"
+msgstr[2] "квинтиліонів"
 
 #: src/humanize/number.py:132
-msgid "octillion"
-msgstr "октильйонів"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "сикстильйонів"
+msgstr[1] "сикстильйонів"
+msgstr[2] "сикстильйонів"
 
 #: src/humanize/number.py:133
-msgid "nonillion"
-msgstr "нонильйонів"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "септильйонів"
+msgstr[1] "септильйонів"
+msgstr[2] "септильйонів"
 
 #: src/humanize/number.py:134
-msgid "decillion"
-msgstr "децильйонів"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "октильйонів"
+msgstr[1] "октильйонів"
+msgstr[2] "октильйонів"
 
 #: src/humanize/number.py:135
-msgid "googol"
-msgstr "гугола"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "нонильйонів"
+msgstr[1] "нонильйонів"
+msgstr[2] "нонильйонів"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "децильйонів"
+msgstr[1] "децильйонів"
+msgstr[2] "децильйонів"
+
+#: src/humanize/number.py:137
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "гугола"
+msgstr[1] "гугола"
+msgstr[2] "гугола"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr "нуль"
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "один"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "два"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "три"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "чотири"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "п'ять"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "шість"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "сім"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "вісім"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "дев'ять"
 

--- a/src/humanize/locale/vi_VI/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/vi_VI/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2017-05-30 11:51+0700\n"
 "Last-Translator: Olivier Cortès <oc@1flow.io>\n"
 "Language-Team: vi_VI <sapd@vccloud.vn>\n"
@@ -19,148 +19,172 @@ msgstr ""
 "Generated-By: Babel 0.9.6\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 msgctxt "0"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 msgctxt "1"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 msgctxt "2"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 msgctxt "3"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 msgctxt "4"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 msgctxt "5"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 msgctxt "6"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 msgctxt "7"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 msgctxt "8"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 msgctxt "9"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "%(value)s triệu"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "tỷ"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/humanize/number.py:127
-msgid "trillion"
-msgstr "%(value)s nghìn tỷ"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "%(value)s triệu"
+msgstr[1] "%(value)s triệu"
 
 #: src/humanize/number.py:128
-msgid "quadrillion"
-msgstr "%(value)s triệu tỷ"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "tỷ"
+msgstr[1] "tỷ"
 
 #: src/humanize/number.py:129
-#, fuzzy
-msgid "quintillion"
-msgstr "%(value)s quintillion"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "%(value)s nghìn tỷ"
+msgstr[1] "%(value)s nghìn tỷ"
 
 #: src/humanize/number.py:130
-#, fuzzy
-msgid "sextillion"
-msgstr "%(value)s sextillion"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "%(value)s triệu tỷ"
+msgstr[1] "%(value)s triệu tỷ"
 
 #: src/humanize/number.py:131
 #, fuzzy
-msgid "septillion"
-msgstr "%(value)s septillion"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "%(value)s quintillion"
+msgstr[1] "%(value)s quintillion"
 
 #: src/humanize/number.py:132
 #, fuzzy
-msgid "octillion"
-msgstr "%(value)s octillion"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "%(value)s sextillion"
+msgstr[1] "%(value)s sextillion"
 
 #: src/humanize/number.py:133
 #, fuzzy
-msgid "nonillion"
-msgstr "%(value)s nonillion"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "%(value)s septillion"
+msgstr[1] "%(value)s septillion"
 
 #: src/humanize/number.py:134
 #, fuzzy
-msgid "decillion"
-msgstr "%(value)s décillion"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "%(value)s octillion"
+msgstr[1] "%(value)s octillion"
 
 #: src/humanize/number.py:135
 #, fuzzy
-msgid "googol"
-msgstr "%(value)s gogol"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "%(value)s nonillion"
+msgstr[1] "%(value)s nonillion"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+#, fuzzy
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "%(value)s décillion"
+msgstr[1] "%(value)s décillion"
+
+#: src/humanize/number.py:137
+#, fuzzy
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "%(value)s gogol"
+msgstr[1] "%(value)s gogol"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr ""
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "một"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "hai"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "ba"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "bốn"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "năm"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "sáu"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "bảy"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "tám"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "chín"
 

--- a/src/humanize/locale/zh_CN/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/zh_CN/LC_MESSAGES/humanize.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 17:01+0300\n"
+"POT-Creation-Date: 2021-04-30 22:34+0200\n"
 "PO-Revision-Date: 2016-11-14 23:02+0000\n"
 "Last-Translator: Liwen SUN <sunliwen@gmail.com>\n"
 "Language-Team: Chinese (simplified)\n"
@@ -18,141 +18,165 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/humanize/number.py:54
+#: src/humanize/number.py:56
 msgctxt "0"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:55
+#: src/humanize/number.py:57
 msgctxt "1"
 msgid "st"
 msgstr "第"
 
-#: src/humanize/number.py:56
+#: src/humanize/number.py:58
 msgctxt "2"
 msgid "nd"
 msgstr "第"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:59
 msgctxt "3"
 msgid "rd"
 msgstr "第"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:60
 msgctxt "4"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:61
 msgctxt "5"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:62
 msgctxt "6"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:63
 msgctxt "7"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:64
 msgctxt "8"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:65
 msgctxt "9"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:124
-msgid "thousand"
-msgstr ""
-
-#: src/humanize/number.py:125
-msgid "million"
-msgstr "百万"
-
 #: src/humanize/number.py:126
-msgid "billion"
-msgstr "十亿"
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/humanize/number.py:127
-msgid "trillion"
-msgstr "兆"
+msgid "million"
+msgid_plural "million"
+msgstr[0] "百万"
+msgstr[1] "百万"
 
 #: src/humanize/number.py:128
-msgid "quadrillion"
-msgstr "万亿"
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "十亿"
+msgstr[1] "十亿"
 
 #: src/humanize/number.py:129
-msgid "quintillion"
-msgstr "百京"
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "兆"
+msgstr[1] "兆"
 
 #: src/humanize/number.py:130
-msgid "sextillion"
-msgstr "十垓"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "万亿"
+msgstr[1] "万亿"
 
 #: src/humanize/number.py:131
-msgid "septillion"
-msgstr "秭"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "百京"
+msgstr[1] "百京"
 
 #: src/humanize/number.py:132
-msgid "octillion"
-msgstr "千秭"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "十垓"
+msgstr[1] "十垓"
 
 #: src/humanize/number.py:133
-msgid "nonillion"
-msgstr "百穰"
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "秭"
+msgstr[1] "秭"
 
 #: src/humanize/number.py:134
-msgid "decillion"
-msgstr "十沟"
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "千秭"
+msgstr[1] "千秭"
 
 #: src/humanize/number.py:135
-msgid "googol"
-msgstr "古高尔"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "百穰"
+msgstr[1] "百穰"
 
-#: src/humanize/number.py:224
+#: src/humanize/number.py:136
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "十沟"
+msgstr[1] "十沟"
+
+#: src/humanize/number.py:137
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "古高尔"
+msgstr[1] "古高尔"
+
+#: src/humanize/number.py:228
 msgid "zero"
 msgstr ""
 
-#: src/humanize/number.py:225
+#: src/humanize/number.py:229
 msgid "one"
 msgstr "一"
 
-#: src/humanize/number.py:226
+#: src/humanize/number.py:230
 msgid "two"
 msgstr "二"
 
-#: src/humanize/number.py:227
+#: src/humanize/number.py:231
 msgid "three"
 msgstr "三"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:232
 msgid "four"
 msgstr "四"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:233
 msgid "five"
 msgstr "五"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:234
 msgid "six"
 msgstr "六"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:235
 msgid "seven"
 msgstr "七"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:236
 msgid "eight"
 msgstr "八"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:237
 msgid "nine"
 msgstr "九"
 

--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -2,6 +2,7 @@
 
 """Humanizing functions for numbers."""
 
+import math
 import re
 from fractions import Fraction
 
@@ -185,12 +186,12 @@ def intword(value, format="%.1f"):
                 chopped = value / float(powers[ordinal])
                 singular, plural = human_powers[ordinal]
                 return (
-                    " ".join([format, ngettext(singular, plural, chopped)])
+                    " ".join([format, ngettext(singular, plural, math.ceil(chopped))])
                 ) % chopped
             else:
                 singular, plural = human_powers[ordinal - 1]
                 return (
-                    " ".join([format, ngettext(singular, plural, chopped)])
+                    " ".join([format, ngettext(singular, plural, math.ceil(chopped))])
                 ) % chopped
     return str(value)
 

--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -6,7 +6,8 @@ import re
 from fractions import Fraction
 
 from .i18n import gettext as _
-from .i18n import gettext_noop as N_
+from .i18n import ngettext
+from .i18n import ngettext_noop as NS_
 from .i18n import pgettext as P_
 from .i18n import thousands_separator
 
@@ -121,18 +122,18 @@ def intcomma(value, ndigits=None):
 
 powers = [10 ** x for x in (3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 100)]
 human_powers = (
-    N_("thousand"),
-    N_("million"),
-    N_("billion"),
-    N_("trillion"),
-    N_("quadrillion"),
-    N_("quintillion"),
-    N_("sextillion"),
-    N_("septillion"),
-    N_("octillion"),
-    N_("nonillion"),
-    N_("decillion"),
-    N_("googol"),
+    NS_("thousand", "thousand"),
+    NS_("million", "million"),
+    NS_("billion", "billion"),
+    NS_("trillion", "trillion"),
+    NS_("quadrillion", "quadrillion"),
+    NS_("quintillion", "quintillion"),
+    NS_("sextillion", "sextillion"),
+    NS_("septillion", "septillion"),
+    NS_("octillion", "octillion"),
+    NS_("nonillion", "nonillion"),
+    NS_("decillion", "decillion"),
+    NS_("googol", "googol"),
 )
 
 
@@ -182,9 +183,15 @@ def intword(value, format="%.1f"):
             chopped = value / float(powers[ordinal - 1])
             if float(format % chopped) == float(10 ** 3):
                 chopped = value / float(powers[ordinal])
-                return (" ".join([format, _(human_powers[ordinal])])) % chopped
+                singular, plural = human_powers[ordinal]
+                return (
+                    " ".join([format, ngettext(singular, plural, chopped)])
+                ) % chopped
             else:
-                return (" ".join([format, _(human_powers[ordinal - 1])])) % chopped
+                singular, plural = human_powers[ordinal - 1]
+                return (
+                    " ".join([format, ngettext(singular, plural, chopped)])
+                ) % chopped
     return str(value)
 
 

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -47,6 +47,28 @@ def test_intcomma():
         assert humanize.intcomma(number) == "10,000,000"
 
 
+@pytest.mark.parametrize(
+    ("locale", "number", "expected_result"),
+    (
+        ("es_ES", 1000000, "1.0 millón"),
+        ("es_ES", 3500000, "3.5 millones"),
+        ("es_ES", 1000000000, "1.0 billón"),
+        ("es_ES", 1200000000, "1.2 billones"),
+        ("es_ES", 1000000000000, "1.0 trillón"),
+        ("es_ES", 6700000000000, "6.7 trillones"),
+    ),
+)
+def test_intword_plurals(locale, number, expected_result):
+    try:
+        humanize.i18n.activate(locale)
+    except FileNotFoundError:
+        pytest.skip("Generate .mo with scripts/generate-translation-binaries.sh")
+    else:
+        assert humanize.intword(number) == expected_result
+    finally:
+        humanize.i18n.deactivate()
+
+
 def test_default_locale_path_defined__file__():
     i18n = importlib.import_module("humanize.i18n")
     assert i18n._get_default_locale_path() is not None


### PR DESCRIPTION
Fixes #193

Changes proposed in this pull request:

* Updates intword to manage plurals.
* Adds `NS_` xgettext function for marking pluralized strings for future translation. 
* Rebuilds locales keeping the same `#, fuzzy` statements, so no previous translations have been broken.
* Updates `es_ES` translation using proper plurals in intword and adding `thousand` translations.
