### PR TITLE
Add gender support for ordinals

### DIFF
--- a/src/humanize/locale/ca_ES/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/ca_ES/LC_MESSAGES/humanize.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2021-04-09 19:57+0200\n"
 "Last-Translator: Jordi Mas i Hernàndez <jmas@softcatala.org>\n"
 "Language-Team: Catalan\n"
@@ -17,165 +17,215 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n!=1;\n"
 "X-Generator: Poedit 2.4.1\n"
 
-#: src/humanize/number.py:56
-msgctxt "0"
-msgid "th"
-msgstr "º"
-
 #: src/humanize/number.py:57
-msgctxt "1"
-msgid "st"
+msgctxt "0 (male)"
+msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:58
-msgctxt "2"
-msgid "nd"
+msgctxt "1 (male)"
+msgid "st"
 msgstr "º"
 
 #: src/humanize/number.py:59
-msgctxt "3"
-msgid "rd"
+msgctxt "2 (male)"
+msgid "nd"
 msgstr "º"
 
 #: src/humanize/number.py:60
-msgctxt "4"
-msgid "th"
+msgctxt "3 (male)"
+msgid "rd"
 msgstr "º"
 
 #: src/humanize/number.py:61
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:62
-msgctxt "6"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:63
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:64
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:65
-msgctxt "9"
+msgctxt "8 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
+msgid "th"
+msgstr "º"
+
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "º"
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "º"
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "º"
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "º"
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "º"
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "º"
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "º"
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "º"
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "º"
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "º"
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "milió"
 msgstr[1] "milió"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "mil milions"
 msgstr[1] "mil milions"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "bilions"
 msgstr[1] "bilions"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "quadrilió"
 msgstr[1] "quadrilió"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "quintillió"
 msgstr[1] "quintillió"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "sextilió"
 msgstr[1] "sextilió"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "septilió"
 msgstr[1] "septilió"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "octilió"
 msgstr[1] "octilió"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "nonilió"
 msgstr[1] "nonilió"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "decilió"
 msgstr[1] "decilió"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googol"
 msgstr[1] "googol"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr "zero"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "un"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "dos"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "tres"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "quatre"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "cinc"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "sis"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "set"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "vuit"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "nou"
 

--- a/src/humanize/locale/de_DE/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/de_DE/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2016-12-18 11:50+0100\n"
 "Last-Translator: Christian Klein <chris@5711.org>\n"
 "Language-Team: German\n"
@@ -19,165 +19,215 @@ msgstr ""
 "Generated-By: Christian Klein\n"
 "X-Generator: Sublime Text 3\n"
 
-#: src/humanize/number.py:56
-msgctxt "0"
-msgid "th"
-msgstr "."
-
 #: src/humanize/number.py:57
-msgctxt "1"
-msgid "st"
+msgctxt "0 (male)"
+msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:58
-msgctxt "2"
-msgid "nd"
+msgctxt "1 (male)"
+msgid "st"
 msgstr "."
 
 #: src/humanize/number.py:59
-msgctxt "3"
-msgid "rd"
+msgctxt "2 (male)"
+msgid "nd"
 msgstr "."
 
 #: src/humanize/number.py:60
-msgctxt "4"
-msgid "th"
+msgctxt "3 (male)"
+msgid "rd"
 msgstr "."
 
 #: src/humanize/number.py:61
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:62
-msgctxt "6"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:63
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:64
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:65
-msgctxt "9"
+msgctxt "8 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "."
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "."
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "."
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "Million"
 msgstr[1] "Million"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "Milliarde"
 msgstr[1] "Milliarde"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "Billion"
 msgstr[1] "Billion"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "Billiarde"
 msgstr[1] "Billiarde"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "Trillion"
 msgstr[1] "Trillion"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "Trilliarde"
 msgstr[1] "Trilliarde"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "Quadrillion"
 msgstr[1] "Quadrillion"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "Quadrillarde"
 msgstr[1] "Quadrillarde"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "Quintillion"
 msgstr[1] "Quintillion"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "Quintilliarde"
 msgstr[1] "Quintilliarde"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "Googol"
 msgstr[1] "Googol"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr "null"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "eins"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "zwei"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "drei"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "vier"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "fünf"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "sechs"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "sieben"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "acht"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "neun"
 

--- a/src/humanize/locale/es_ES/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/es_ES/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2020-03-31 21:08+0200\n"
 "Last-Translator: Álvaro Mondéjar <mondejar1994@gmail.com>\n"
 "Language-Team: \n"
@@ -18,165 +18,215 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/humanize/number.py:56
-msgctxt "0"
-msgid "th"
-msgstr "º"
-
 #: src/humanize/number.py:57
-msgctxt "1"
-msgid "st"
+msgctxt "0 (male)"
+msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:58
-msgctxt "2"
-msgid "nd"
+msgctxt "1 (male)"
+msgid "st"
 msgstr "º"
 
 #: src/humanize/number.py:59
-msgctxt "3"
-msgid "rd"
+msgctxt "2 (male)"
+msgid "nd"
 msgstr "º"
 
 #: src/humanize/number.py:60
-msgctxt "4"
-msgid "th"
+msgctxt "3 (male)"
+msgid "rd"
 msgstr "º"
 
 #: src/humanize/number.py:61
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:62
-msgctxt "6"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:63
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:64
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:65
-msgctxt "9"
+msgctxt "8 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
+msgid "th"
+msgstr "º"
+
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "ª"
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "ª"
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "ª"
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] "mil"
 msgstr[1] "mil"
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "millón"
 msgstr[1] "millones"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "billón"
 msgstr[1] "billones"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "trillón"
 msgstr[1] "trillones"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "quatrillón"
 msgstr[1] "quatrillones"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "quintillón"
 msgstr[1] "quintillones"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "sextillón"
 msgstr[1] "sextillones"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "septillón"
 msgstr[1] "septillones"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "octillón"
 msgstr[1] "octillones"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "nonillón"
 msgstr[1] "nonillones"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "decillón"
 msgstr[1] "decillones"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "gúgol"
 msgstr[1] "gúgol"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr "cero"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "uno"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "dos"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "tres"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "cuatro"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "cinco"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "seis"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "siete"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "ocho"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "nueve"
 

--- a/src/humanize/locale/fa_IR/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/fa_IR/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2017-01-10 02:44+0330\n"
 "Last-Translator: Christian Klein <chris@5711.org>\n"
 "Language-Team: German\n"
@@ -19,165 +19,215 @@ msgstr ""
 "Generated-By: Christian Klein\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: src/humanize/number.py:56
-msgctxt "0"
+#: src/humanize/number.py:57
+msgctxt "0 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:57
-msgctxt "1"
+#: src/humanize/number.py:58
+msgctxt "1 (male)"
 msgid "st"
 msgstr "اولین"
 
-#: src/humanize/number.py:58
-msgctxt "2"
+#: src/humanize/number.py:59
+msgctxt "2 (male)"
 msgid "nd"
 msgstr "دومین"
 
-#: src/humanize/number.py:59
-msgctxt "3"
+#: src/humanize/number.py:60
+msgctxt "3 (male)"
 msgid "rd"
 msgstr "سومین"
 
-#: src/humanize/number.py:60
-msgctxt "4"
-msgid "th"
-msgstr "چهارمین"
-
 #: src/humanize/number.py:61
-msgctxt "5"
+msgctxt "4 (male)"
+msgid "th"
+msgstr "چهارمی"
+
+#: src/humanize/number.py:62
+msgctxt "5 (male)"
 msgid "th"
 msgstr "پنجمین"
 
-#: src/humanize/number.py:62
-msgctxt "6"
-msgid "th"
-msgstr "ششمین"
-
 #: src/humanize/number.py:63
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
-msgstr "هفتمین"
+msgstr "ششمی"
 
 #: src/humanize/number.py:64
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
-msgstr "هشتمین"
+msgstr "هفتمی"
 
 #: src/humanize/number.py:65
-msgctxt "9"
+msgctxt "8 (male)"
+msgid "th"
+msgstr "هشتمی"
+
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
 msgid "th"
 msgstr "نهمین"
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "اولین"
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "دومین"
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "سومین"
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "چهارمی"
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "پنجمین"
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "ششمی"
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "هفتمی"
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "هشتمی"
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "نهمین"
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "میلیون"
 msgstr[1] "میلیون"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "میلیارد"
 msgstr[1] "میلیارد"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "ترلیون"
 msgstr[1] "ترلیون"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "کوادریلیون"
 msgstr[1] "کوادریلیون"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "کوانتیلیون"
 msgstr[1] "کوانتیلیون"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "سکستیلیون"
 msgstr[1] "سکستیلیون"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "سپتیلیون"
 msgstr[1] "سپتیلیون"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "اوکتیلیون"
 msgstr[1] "اوکتیلیون"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "نونیلیون"
 msgstr[1] "نونیلیون"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "دسیلیون"
 msgstr[1] "دسیلیون"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "گوگول"
 msgstr[1] "گوگول"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr ""
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "یک"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "دو"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "سه"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "چهار"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "پنج"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "شش"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "هفت"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "هشت"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "نه"
 

--- a/src/humanize/locale/fi_FI/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/fi_FI/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2017-03-02 11:26+0200\n"
 "Last-Translator: Ville Skyttä <ville.skytta@iki.fi>\n"
 "Language-Team: Finnish\n"
@@ -18,165 +18,215 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.12\n"
 
-#: src/humanize/number.py:56
-msgctxt "0"
-msgid "th"
-msgstr "."
-
 #: src/humanize/number.py:57
-msgctxt "1"
-msgid "st"
+msgctxt "0 (male)"
+msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:58
-msgctxt "2"
-msgid "nd"
+msgctxt "1 (male)"
+msgid "st"
 msgstr "."
 
 #: src/humanize/number.py:59
-msgctxt "3"
-msgid "rd"
+msgctxt "2 (male)"
+msgid "nd"
 msgstr "."
 
 #: src/humanize/number.py:60
-msgctxt "4"
-msgid "th"
+msgctxt "3 (male)"
+msgid "rd"
 msgstr "."
 
 #: src/humanize/number.py:61
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:62
-msgctxt "6"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:63
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:64
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:65
-msgctxt "9"
+msgctxt "8 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "."
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "."
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "."
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] "tuhatta"
 msgstr[1] "tuhatta"
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "miljoonaa"
 msgstr[1] "miljoonaa"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "miljardia"
 msgstr[1] "miljardia"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "biljoonaa"
 msgstr[1] "biljoonaa"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "kvadriljoonaa"
 msgstr[1] "kvadriljoonaa"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "kvintiljoonaa"
 msgstr[1] "kvintiljoonaa"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "sekstiljoonaa"
 msgstr[1] "sekstiljoonaa"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "septiljoonaa"
 msgstr[1] "septiljoonaa"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "oktiljoonaa"
 msgstr[1] "oktiljoonaa"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "noniljoonaa"
 msgstr[1] "noniljoonaa"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "dekiljoonaa"
 msgstr[1] "dekiljoonaa"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googol"
 msgstr[1] "googol"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr "nolla"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "yksi"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "kaksi"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "kolme"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "neljä"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "viisi"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "kuusi"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "seitsemän"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "kahdeksan"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "yhdeksän"
 

--- a/src/humanize/locale/fr_FR/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/fr_FR/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2013-06-22 08:52+0100\n"
 "Last-Translator: Olivier Cortès <oc@1flow.io>\n"
 "Language-Team: fr_FR <LL@li.org>\n"
@@ -19,185 +19,225 @@ msgstr ""
 "Generated-By: Babel 0.9.6\n"
 "X-Generator: Poedit 1.5.5\n"
 
-#: src/humanize/number.py:56
-#, fuzzy
-msgctxt "0"
+#: src/humanize/number.py:57
+msgctxt "0 (male)"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:57
-#, fuzzy
-msgctxt "1"
+#: src/humanize/number.py:58
+msgctxt "1 (male)"
 msgid "st"
 msgstr "er"
 
-#: src/humanize/number.py:58
-#, fuzzy
-msgctxt "2"
+#: src/humanize/number.py:59
+msgctxt "2 (male)"
 msgid "nd"
 msgstr "e"
 
-#: src/humanize/number.py:59
-#, fuzzy
-msgctxt "3"
+#: src/humanize/number.py:60
+msgctxt "3 (male)"
 msgid "rd"
 msgstr "e"
 
-#: src/humanize/number.py:60
-#, fuzzy
-msgctxt "4"
-msgid "th"
-msgstr "e"
-
 #: src/humanize/number.py:61
-#, fuzzy
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "e"
 
 #: src/humanize/number.py:62
-#, fuzzy
-msgctxt "6"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "e"
 
 #: src/humanize/number.py:63
-#, fuzzy
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
 msgstr "e"
 
 #: src/humanize/number.py:64
-#, fuzzy
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
 msgstr "e"
 
 #: src/humanize/number.py:65
-#, fuzzy
-msgctxt "9"
+msgctxt "8 (male)"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
+msgid "th"
+msgstr "e"
+
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "e"
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "ère"
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "e"
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "e"
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "e"
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "e"
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "e"
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "e"
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "e"
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "e"
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 #, fuzzy
 msgid "million"
 msgid_plural "million"
 msgstr[0] "%(value)s million"
 msgstr[1] "%(value)s million"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "milliard"
 msgstr[1] "milliard"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 #, fuzzy
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "%(value)s billion"
 msgstr[1] "%(value)s billion"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 #, fuzzy
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "%(value)s billiard"
 msgstr[1] "%(value)s billiard"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 #, fuzzy
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "%(value)s trillion"
 msgstr[1] "%(value)s trillion"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 #, fuzzy
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "%(value)s trilliard"
 msgstr[1] "%(value)s trilliard"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 #, fuzzy
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "%(value)s quatrillion"
 msgstr[1] "%(value)s quatrillion"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 #, fuzzy
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "%(value)s quadrilliard"
 msgstr[1] "%(value)s quadrilliard"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 #, fuzzy
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "%(value)s quintillion"
 msgstr[1] "%(value)s quintillion"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 #, fuzzy
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "%(value)s quintilliard"
 msgstr[1] "%(value)s quintilliard"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 #, fuzzy
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "%(value)s gogol"
 msgstr[1] "%(value)s gogol"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr "zéro"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "un"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "deux"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "trois"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "quatre"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "cinq"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "six"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "sept"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "huit"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "neuf"
 

--- a/src/humanize/locale/id_ID/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/id_ID/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2017-03-18 15:41+0700\n"
 "Last-Translator: adie.rebel@gmail.com\n"
 "Language-Team: Indonesian\n"
@@ -18,153 +18,203 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 1.8.11\n"
 
-#: src/humanize/number.py:56
-msgctxt "0"
-msgid "th"
-msgstr "."
-
 #: src/humanize/number.py:57
-msgctxt "1"
-msgid "st"
+msgctxt "0 (male)"
+msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:58
-msgctxt "2"
-msgid "nd"
+msgctxt "1 (male)"
+msgid "st"
 msgstr "."
 
 #: src/humanize/number.py:59
-msgctxt "3"
-msgid "rd"
+msgctxt "2 (male)"
+msgid "nd"
 msgstr "."
 
 #: src/humanize/number.py:60
-msgctxt "4"
-msgid "th"
+msgctxt "3 (male)"
+msgid "rd"
 msgstr "."
 
 #: src/humanize/number.py:61
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:62
-msgctxt "6"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:63
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:64
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:65
-msgctxt "9"
+msgctxt "8 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "."
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "."
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "."
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "juta"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "miliar"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "triliun"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "kuadriliun"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "quintillion"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "sextillion"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "septillion"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "octillion"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "nonillion"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "decillion"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googol"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr "nol"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "satu"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "dua"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "tiga"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "empat"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "lima"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "enam"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "tujuh"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "delapan"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "sembilan"
 

--- a/src/humanize/locale/it_IT/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/it_IT/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2018-10-27 22:52+0200\n"
 "Last-Translator: derfel <code@derfel.net>\n"
 "Language-Team: Italian\n"
@@ -18,165 +18,215 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.2\n"
 
-#: src/humanize/number.py:56
-msgctxt "0"
-msgid "th"
-msgstr "º"
-
 #: src/humanize/number.py:57
-msgctxt "1"
-msgid "st"
+msgctxt "0 (male)"
+msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:58
-msgctxt "2"
-msgid "nd"
+msgctxt "1 (male)"
+msgid "st"
 msgstr "º"
 
 #: src/humanize/number.py:59
-msgctxt "3"
-msgid "rd"
+msgctxt "2 (male)"
+msgid "nd"
 msgstr "º"
 
 #: src/humanize/number.py:60
-msgctxt "4"
-msgid "th"
+msgctxt "3 (male)"
+msgid "rd"
 msgstr "º"
 
 #: src/humanize/number.py:61
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:62
-msgctxt "6"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:63
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:64
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:65
-msgctxt "9"
+msgctxt "8 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
+msgid "th"
+msgstr "º"
+
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "ª"
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "ª"
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "ª"
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "milioni"
 msgstr[1] "milioni"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "miliardi"
 msgstr[1] "miliardi"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "bilioni"
 msgstr[1] "bilioni"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "biliardi"
 msgstr[1] "biliardi"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "trilioni"
 msgstr[1] "trilioni"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "triliardi"
 msgstr[1] "triliardi"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "quadrilioni"
 msgstr[1] "quadrilioni"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "quadriliardi"
 msgstr[1] "quadriliardi"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "quintilioni"
 msgstr[1] "quintilioni"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "quintiliardi"
 msgstr[1] "quintiliardi"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googol"
 msgstr[1] "googol"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr "zero"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "uno"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "due"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "tre"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "quattro"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "cinque"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "sei"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "sette"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "otto"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "nove"
 

--- a/src/humanize/locale/ja_JP/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/ja_JP/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2018-01-22 10:48+0900\n"
 "Last-Translator: Kan Torii <oss@qoolloop.com>\n"
 "Language-Team: Japanese\n"
@@ -19,162 +19,212 @@ msgstr ""
 "Generated-By: Babel 0.9.6\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: src/humanize/number.py:56
-msgctxt "0"
-msgid "th"
-msgstr "番目"
-
 #: src/humanize/number.py:57
-msgctxt "1"
-msgid "st"
+msgctxt "0 (male)"
+msgid "th"
 msgstr "番目"
 
 #: src/humanize/number.py:58
-msgctxt "2"
-msgid "nd"
+msgctxt "1 (male)"
+msgid "st"
 msgstr "番目"
 
 #: src/humanize/number.py:59
-msgctxt "3"
-msgid "rd"
+msgctxt "2 (male)"
+msgid "nd"
 msgstr "番目"
 
 #: src/humanize/number.py:60
-msgctxt "4"
-msgid "th"
+msgctxt "3 (male)"
+msgid "rd"
 msgstr "番目"
 
 #: src/humanize/number.py:61
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "番目"
 
 #: src/humanize/number.py:62
-msgctxt "6"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "番目"
 
 #: src/humanize/number.py:63
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
 msgstr "番目"
 
 #: src/humanize/number.py:64
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
 msgstr "番目"
 
 #: src/humanize/number.py:65
-msgctxt "9"
+msgctxt "8 (male)"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
+msgid "th"
+msgstr "番目"
+
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "番目"
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "番目"
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "番目"
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "番目"
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "番目"
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "番目"
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "番目"
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "番目"
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "番目"
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "番目"
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "百万"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 #, fuzzy
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "十億"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "兆"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 #, fuzzy
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "千兆"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 #, fuzzy
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "百京"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 #, fuzzy
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "十垓"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 #, fuzzy
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "じょ"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 #, fuzzy
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "千じょ"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 #, fuzzy
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "百穣"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 #, fuzzy
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "十溝"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 #, fuzzy
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "溝無量大数"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr ""
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "一"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "二"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "三"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "四"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "五"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "六"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "七"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "八"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "九"
 

--- a/src/humanize/locale/ko_KR/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/ko_KR/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2013-07-10 11:38+0900\n"
 "Last-Translator: @youngrok\n"
 "Language-Team: ko_KR <LL@li.org>\n"
@@ -19,184 +19,244 @@ msgstr ""
 "Generated-By: Babel 0.9.6\n"
 "X-Generator: Poedit 1.5.7\n"
 
-#: src/humanize/number.py:56
-#, fuzzy
-msgctxt "0"
-msgid "th"
-msgstr "번째"
-
 #: src/humanize/number.py:57
 #, fuzzy
-msgctxt "1"
-msgid "st"
+msgctxt "0 (male)"
+msgid "th"
 msgstr "번째"
 
 #: src/humanize/number.py:58
 #, fuzzy
-msgctxt "2"
-msgid "nd"
+msgctxt "1 (male)"
+msgid "st"
 msgstr "번째"
 
 #: src/humanize/number.py:59
 #, fuzzy
-msgctxt "3"
-msgid "rd"
+msgctxt "2 (male)"
+msgid "nd"
 msgstr "번째"
 
 #: src/humanize/number.py:60
 #, fuzzy
-msgctxt "4"
-msgid "th"
+msgctxt "3 (male)"
+msgid "rd"
 msgstr "번째"
 
 #: src/humanize/number.py:61
 #, fuzzy
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "번째"
 
 #: src/humanize/number.py:62
 #, fuzzy
-msgctxt "6"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "번째"
 
 #: src/humanize/number.py:63
 #, fuzzy
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
 msgstr "번째"
 
 #: src/humanize/number.py:64
 #, fuzzy
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
 msgstr "번째"
 
 #: src/humanize/number.py:65
 #, fuzzy
-msgctxt "9"
+msgctxt "8 (male)"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:66
+#, fuzzy
+msgctxt "9 (male)"
+msgid "th"
+msgstr "번째"
+
+#: src/humanize/number.py:70
+#, fuzzy
+msgctxt "0 (female)"
+msgid "th"
+msgstr "번째"
+
+#: src/humanize/number.py:71
+#, fuzzy
+msgctxt "1 (female)"
+msgid "st"
+msgstr "번째"
+
+#: src/humanize/number.py:72
+#, fuzzy
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "번째"
+
+#: src/humanize/number.py:73
+#, fuzzy
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "번째"
+
+#: src/humanize/number.py:74
+#, fuzzy
+msgctxt "4 (female)"
+msgid "th"
+msgstr "번째"
+
+#: src/humanize/number.py:75
+#, fuzzy
+msgctxt "5 (female)"
+msgid "th"
+msgstr "번째"
+
+#: src/humanize/number.py:76
+#, fuzzy
+msgctxt "6 (female)"
+msgid "th"
+msgstr "번째"
+
+#: src/humanize/number.py:77
+#, fuzzy
+msgctxt "7 (female)"
+msgid "th"
+msgstr "번째"
+
+#: src/humanize/number.py:78
+#, fuzzy
+msgctxt "8 (female)"
+msgid "th"
+msgstr "번째"
+
+#: src/humanize/number.py:79
+#, fuzzy
+msgctxt "9 (female)"
+msgid "th"
+msgstr "번째"
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "%(value)s million"
 msgstr[1] "%(value)s million"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "milliard"
 msgstr[1] "milliard"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 #, fuzzy
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "%(value)s billion"
 msgstr[1] "%(value)s billion"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 #, fuzzy
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "%(value)s quadrillion"
 msgstr[1] "%(value)s quadrillion"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 #, fuzzy
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "%(value)s quintillion"
 msgstr[1] "%(value)s quintillion"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 #, fuzzy
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "%(value)s sextillion"
 msgstr[1] "%(value)s sextillion"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 #, fuzzy
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "%(value)s septillion"
 msgstr[1] "%(value)s septillion"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 #, fuzzy
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "%(value)s octillion"
 msgstr[1] "%(value)s octillion"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 #, fuzzy
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "%(value)s nonillion"
 msgstr[1] "%(value)s nonillion"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 #, fuzzy
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "%(value)s décillion"
 msgstr[1] "%(value)s décillion"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 #, fuzzy
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "%(value)s gogol"
 msgstr[1] "%(value)s gogol"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr ""
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "하나"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "둘"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "셋"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "넷"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "다섯"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "여섯"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "일곱"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "여덟"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "아홉"
 

--- a/src/humanize/locale/nl_NL/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/nl_NL/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2015-03-25 21:08+0100\n"
 "Last-Translator: Martin van Wingerden\n"
 "Language-Team: nl_NL\n"
@@ -19,165 +19,215 @@ msgstr ""
 "Generated-By: Babel 0.9.6\n"
 "X-Generator: Poedit 1.7.5\n"
 
-#: src/humanize/number.py:56
-msgctxt "0"
+#: src/humanize/number.py:57
+msgctxt "0 (male)"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:57
-msgctxt "1"
+#: src/humanize/number.py:58
+msgctxt "1 (male)"
 msgid "st"
 msgstr "ste"
 
-#: src/humanize/number.py:58
-msgctxt "2"
+#: src/humanize/number.py:59
+msgctxt "2 (male)"
 msgid "nd"
 msgstr "de"
 
-#: src/humanize/number.py:59
-msgctxt "3"
+#: src/humanize/number.py:60
+msgctxt "3 (male)"
 msgid "rd"
 msgstr "de"
 
-#: src/humanize/number.py:60
-msgctxt "4"
-msgid "th"
-msgstr "de"
-
 #: src/humanize/number.py:61
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "de"
 
 #: src/humanize/number.py:62
-msgctxt "6"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "de"
 
 #: src/humanize/number.py:63
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
 msgstr "de"
 
 #: src/humanize/number.py:64
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
 msgstr "de"
 
 #: src/humanize/number.py:65
-msgctxt "9"
+msgctxt "8 (male)"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
+msgid "th"
+msgstr "de"
+
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "de"
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "ste"
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "de"
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "de"
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "de"
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "de"
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "de"
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "de"
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "de"
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "de"
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "miljoen"
 msgstr[1] "miljoen"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "miljard"
 msgstr[1] "miljard"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "biljoen"
 msgstr[1] "biljoen"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "biljard"
 msgstr[1] "biljard"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "triljoen"
 msgstr[1] "triljoen"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "triljard"
 msgstr[1] "triljard"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "quadriljoen"
 msgstr[1] "quadriljoen"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "quadriljard"
 msgstr[1] "quadriljard"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "quintiljoen"
 msgstr[1] "quintiljoen"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "quintiljard"
 msgstr[1] "quintiljard"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googol"
 msgstr[1] "googol"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr "nul"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "één"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "twee"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "drie"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "vier"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "vijf"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "zes"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "zeven"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "acht"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "negen"
 

--- a/src/humanize/locale/pl_PL/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/pl_PL/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2020-04-22 10:02+0200\n"
 "Last-Translator: Bartosz Bubak <bartosz.bubak gmail com>\n"
 "Language-Team: Polish\n"
@@ -18,177 +18,227 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-#: src/humanize/number.py:56
-msgctxt "0"
-msgid "th"
-msgstr "."
-
 #: src/humanize/number.py:57
-msgctxt "1"
-msgid "st"
+msgctxt "0 (male)"
+msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:58
-msgctxt "2"
-msgid "nd"
+msgctxt "1 (male)"
+msgid "st"
 msgstr "."
 
 #: src/humanize/number.py:59
-msgctxt "3"
-msgid "rd"
+msgctxt "2 (male)"
+msgid "nd"
 msgstr "."
 
 #: src/humanize/number.py:60
-msgctxt "4"
-msgid "th"
+msgctxt "3 (male)"
+msgid "rd"
 msgstr "."
 
 #: src/humanize/number.py:61
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:62
-msgctxt "6"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:63
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:64
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:65
-msgctxt "9"
+msgctxt "8 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "."
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "."
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "."
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "milion"
 msgstr[1] "milion"
 msgstr[2] "milion"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "bilion"
 msgstr[1] "bilion"
 msgstr[2] "bilion"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "trylion"
 msgstr[1] "trylion"
 msgstr[2] "trylion"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "kwadrylion"
 msgstr[1] "kwadrylion"
 msgstr[2] "kwadrylion"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "kwintylion"
 msgstr[1] "kwintylion"
 msgstr[2] "kwintylion"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "sekstylion"
 msgstr[1] "sekstylion"
 msgstr[2] "sekstylion"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "septylion"
 msgstr[1] "septylion"
 msgstr[2] "septylion"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "oktylion"
 msgstr[1] "oktylion"
 msgstr[2] "oktylion"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "nonilion"
 msgstr[1] "nonilion"
 msgstr[2] "nonilion"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "decylion"
 msgstr[1] "decylion"
 msgstr[2] "decylion"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googol"
 msgstr[1] "googol"
 msgstr[2] "googol"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr "zero"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "jeden"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "dwa"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "trzy"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "cztery"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "pięć"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "sześć"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "siedem"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "osiem"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "dziewięć"
 

--- a/src/humanize/locale/pt_BR/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/pt_BR/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2016-06-15 15:58-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,165 +18,215 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 1.8.5\n"
 
-#: src/humanize/number.py:56
-msgctxt "0"
-msgid "th"
-msgstr "º"
-
 #: src/humanize/number.py:57
-msgctxt "1"
-msgid "st"
+msgctxt "0 (male)"
+msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:58
-msgctxt "2"
-msgid "nd"
+msgctxt "1 (male)"
+msgid "st"
 msgstr "º"
 
 #: src/humanize/number.py:59
-msgctxt "3"
-msgid "rd"
+msgctxt "2 (male)"
+msgid "nd"
 msgstr "º"
 
 #: src/humanize/number.py:60
-msgctxt "4"
-msgid "th"
+msgctxt "3 (male)"
+msgid "rd"
 msgstr "º"
 
 #: src/humanize/number.py:61
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:62
-msgctxt "6"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:63
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:64
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:65
-msgctxt "9"
+msgctxt "8 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
+msgid "th"
+msgstr "º"
+
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "ª"
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "ª"
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "ª"
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "milhão"
 msgstr[1] "milhão"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "bilhão"
 msgstr[1] "bilhão"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "trilhão"
 msgstr[1] "trilhão"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "quatrilhão"
 msgstr[1] "quatrilhão"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "quintilhão"
 msgstr[1] "quintilhão"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "sextilhão"
 msgstr[1] "sextilhão"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "septilhão"
 msgstr[1] "septilhão"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "octilhão"
 msgstr[1] "octilhão"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "nonilhão"
 msgstr[1] "nonilhão"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "decilhão"
 msgstr[1] "decilhão"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "undecilhão"
 msgstr[1] "undecilhão"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr "zero"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "um"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "dois"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "três"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "quatro"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "cinco"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "seis"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "sete"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "oito"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "nove"
 

--- a/src/humanize/locale/pt_PT/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/pt_PT/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2020-07-05 18:17+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,165 +18,215 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.3.1\n"
 
-#: src/humanize/number.py:56
-msgctxt "0"
-msgid "th"
-msgstr "º"
-
 #: src/humanize/number.py:57
-msgctxt "1"
-msgid "st"
+msgctxt "0 (male)"
+msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:58
-msgctxt "2"
-msgid "nd"
+msgctxt "1 (male)"
+msgid "st"
 msgstr "º"
 
 #: src/humanize/number.py:59
-msgctxt "3"
-msgid "rd"
+msgctxt "2 (male)"
+msgid "nd"
 msgstr "º"
 
 #: src/humanize/number.py:60
-msgctxt "4"
-msgid "th"
+msgctxt "3 (male)"
+msgid "rd"
 msgstr "º"
 
 #: src/humanize/number.py:61
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:62
-msgctxt "6"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:63
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:64
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
 msgstr "º"
 
 #: src/humanize/number.py:65
-msgctxt "9"
+msgctxt "8 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
+msgid "th"
+msgstr "º"
+
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "ª"
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "ª"
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "ª"
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "ª"
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "milhão"
 msgstr[1] "milhão"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "milhar de milhão"
 msgstr[1] "milhar de milhão"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "bilião"
 msgstr[1] "bilião"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "mil biliões"
 msgstr[1] "mil biliões"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "trilião"
 msgstr[1] "trilião"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "mil triliões"
 msgstr[1] "mil triliões"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "quatrilião"
 msgstr[1] "quatrilião"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "mil quatriliões"
 msgstr[1] "mil quatriliões"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "quintilhão"
 msgstr[1] "quintilhão"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "mil quintilhões"
 msgstr[1] "mil quintilhões"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "sextilhão"
 msgstr[1] "sextilhão"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr "zero"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "um"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "dois"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "três"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "quatro"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "cinco"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "seis"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "sete"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "oito"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "nove"
 

--- a/src/humanize/locale/ru_RU/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/ru_RU/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2014-03-24 20:32+0300\n"
 "Last-Translator: Sergey Prokhorov <me@seriyps.ru>\n"
 "Language-Team: ru_RU <LL@li.org>\n"
@@ -20,184 +20,227 @@ msgstr ""
 "Generated-By: Babel 0.9.6\n"
 "X-Generator: Poedit 1.5.4\n"
 
-# в Django тут "ий" но на самом деле оба варианта работают плохо
-#: src/humanize/number.py:56
-msgctxt "0"
+#: src/humanize/number.py:57
+msgctxt "0 (male)"
 msgid "th"
 msgstr "ой"
 
-#: src/humanize/number.py:57
-msgctxt "1"
+#: src/humanize/number.py:58
+msgctxt "1 (male)"
 msgid "st"
 msgstr "ый"
 
-#: src/humanize/number.py:58
-msgctxt "2"
+#: src/humanize/number.py:59
+msgctxt "2 (male)"
 msgid "nd"
 msgstr "ой"
 
-#: src/humanize/number.py:59
-msgctxt "3"
+#: src/humanize/number.py:60
+msgctxt "3 (male)"
 msgid "rd"
 msgstr "ий"
 
-# в Django тут "ий" но на самом деле оба варианта работают плохо
-#: src/humanize/number.py:60
-msgctxt "4"
-msgid "th"
-msgstr "ый"
-
-# в Django тут "ий" но на самом деле оба варианта работают плохо
 #: src/humanize/number.py:61
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "ый"
 
-# в Django тут "ий" но на самом деле оба варианта работают плохо
 #: src/humanize/number.py:62
-msgctxt "6"
-msgid "th"
-msgstr "ой"
-
-# в Django тут "ий" но на самом деле оба варианта работают плохо
-#: src/humanize/number.py:63
-msgctxt "7"
-msgid "th"
-msgstr "ой"
-
-# в Django тут "ий" но на самом деле оба варианта работают плохо
-#: src/humanize/number.py:64
-msgctxt "8"
-msgid "th"
-msgstr "ой"
-
-# в Django тут "ий" но на самом деле оба варианта работают плохо
-#: src/humanize/number.py:65
-msgctxt "9"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "ый"
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:63
+msgctxt "6 (male)"
+msgid "th"
+msgstr "ой"
+
+#: src/humanize/number.py:64
+msgctxt "7 (male)"
+msgid "th"
+msgstr "ой"
+
+#: src/humanize/number.py:65
+msgctxt "8 (male)"
+msgid "th"
+msgstr "ой"
+
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
+msgid "th"
+msgstr "ый"
+
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "ой"
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "ый"
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "ой"
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "ий"
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "ый"
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "ый"
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "ой"
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "ой"
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "ой"
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "ый"
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "миллиона"
 msgstr[1] "миллиона"
 msgstr[2] "миллиона"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "миллиарда"
 msgstr[1] "миллиарда"
 msgstr[2] "миллиарда"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "триллиона"
 msgstr[1] "триллиона"
 msgstr[2] "триллиона"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "квадриллиона"
 msgstr[1] "квадриллиона"
 msgstr[2] "квадриллиона"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "квинтиллиона"
 msgstr[1] "квинтиллиона"
 msgstr[2] "квинтиллиона"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "сикстиллиона"
 msgstr[1] "сикстиллиона"
 msgstr[2] "сикстиллиона"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "септиллиона"
 msgstr[1] "септиллиона"
 msgstr[2] "септиллиона"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "октиллиона"
 msgstr[1] "октиллиона"
 msgstr[2] "октиллиона"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "нониллиона"
 msgstr[1] "нониллиона"
 msgstr[2] "нониллиона"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "децилиона"
 msgstr[1] "децилиона"
 msgstr[2] "децилиона"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "гогола"
 msgstr[1] "гогола"
 msgstr[2] "гогола"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr ""
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "один"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "два"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "три"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "четыре"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "пять"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "шесть"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "семь"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "восемь"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "девять"
 

--- a/src/humanize/locale/sk_SK/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/sk_SK/LC_MESSAGES/humanize.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2020-09-29 22:43+0300\n"
 "Last-Translator: Jose Riha <jose1711 gmail com>\n"
 "Language-Team: sk <LL@li.org>\n"
@@ -18,177 +18,227 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: src/humanize/number.py:56
-msgctxt "0"
-msgid "th"
-msgstr "."
-
 #: src/humanize/number.py:57
-msgctxt "1"
-msgid "st"
+msgctxt "0 (male)"
+msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:58
-msgctxt "2"
-msgid "nd"
+msgctxt "1 (male)"
+msgid "st"
 msgstr "."
 
 #: src/humanize/number.py:59
-msgctxt "3"
-msgid "rd"
+msgctxt "2 (male)"
+msgid "nd"
 msgstr "."
 
 #: src/humanize/number.py:60
-msgctxt "4"
-msgid "th"
+msgctxt "3 (male)"
+msgid "rd"
 msgstr "."
 
 #: src/humanize/number.py:61
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:62
-msgctxt "6"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:63
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:64
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:65
-msgctxt "9"
+msgctxt "8 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "."
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "."
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "."
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "milióna/ov"
 msgstr[1] "milióna/ov"
 msgstr[2] "milióna/ov"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "miliardy/árd"
 msgstr[1] "miliardy/árd"
 msgstr[2] "miliardy/árd"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "bilióna/ov"
 msgstr[1] "bilióna/ov"
 msgstr[2] "bilióna/ov"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "biliardy/árd"
 msgstr[1] "biliardy/árd"
 msgstr[2] "biliardy/árd"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "trilióna/árd"
 msgstr[1] "trilióna/árd"
 msgstr[2] "trilióna/árd"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "triliardy/árd"
 msgstr[1] "triliardy/árd"
 msgstr[2] "triliardy/árd"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "kvadrilióna/ov"
 msgstr[1] "kvadrilióna/ov"
 msgstr[2] "kvadrilióna/ov"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "kvadriliardy/árd"
 msgstr[1] "kvadriliardy/árd"
 msgstr[2] "kvadriliardy/árd"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "kvintilióna/ov"
 msgstr[1] "kvintilióna/ov"
 msgstr[2] "kvintilióna/ov"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "kvintiliardy/árd"
 msgstr[1] "kvintiliardy/árd"
 msgstr[2] "kvintiliardy/árd"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googola/ov"
 msgstr[1] "googola/ov"
 msgstr[2] "googola/ov"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr "nula"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "jedna"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "dve"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "tri"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "štyri"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "päť"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "šesť"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "sedem"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "osem"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "deväť"
 

--- a/src/humanize/locale/tr_TR/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/tr_TR/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2017-02-23 20:00+0300\n"
 "Last-Translator: Emre Çintay <emre@cintay.com>\n"
 "Language-Team: Turkish\n"
@@ -19,165 +19,215 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Generated-By: Emre Çintay\n"
 
-#: src/humanize/number.py:56
-msgctxt "0"
-msgid "th"
-msgstr "."
-
 #: src/humanize/number.py:57
-msgctxt "1"
-msgid "st"
+msgctxt "0 (male)"
+msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:58
-msgctxt "2"
-msgid "nd"
+msgctxt "1 (male)"
+msgid "st"
 msgstr "."
 
 #: src/humanize/number.py:59
-msgctxt "3"
-msgid "rd"
+msgctxt "2 (male)"
+msgid "nd"
 msgstr "."
 
 #: src/humanize/number.py:60
-msgctxt "4"
-msgid "th"
+msgctxt "3 (male)"
+msgid "rd"
 msgstr "."
 
 #: src/humanize/number.py:61
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:62
-msgctxt "6"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:63
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:64
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:65
-msgctxt "9"
+msgctxt "8 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "."
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "."
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "."
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "milyon"
 msgstr[1] "milyon"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "milyar"
 msgstr[1] "milyar"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "trilyon"
 msgstr[1] "trilyon"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "katrilyon"
 msgstr[1] "katrilyon"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "kentilyon"
 msgstr[1] "kentilyon"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "sekstilyon"
 msgstr[1] "sekstilyon"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "septilyon"
 msgstr[1] "septilyon"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "oktilyon"
 msgstr[1] "oktilyon"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "nonilyon"
 msgstr[1] "nonilyon"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "desilyon"
 msgstr[1] "desilyon"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googol"
 msgstr[1] "googol"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr ""
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "bir"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "iki"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "üç"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "dört"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "beş"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "altı"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "yedi"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "sekiz"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "dokuz"
 

--- a/src/humanize/locale/uk_UA/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/uk_UA/LC_MESSAGES/humanize.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: TL\n"
 "Language-Team: uk_UA\n"
@@ -15,177 +15,227 @@ msgstr ""
 "Generated-By:\n"
 "X-Generator: \n"
 
-#: src/humanize/number.py:56
-msgctxt "0"
-msgid "th"
-msgstr "ий"
-
 #: src/humanize/number.py:57
-msgctxt "1"
-msgid "st"
+msgctxt "0 (male)"
+msgid "th"
 msgstr "ий"
 
 #: src/humanize/number.py:58
-msgctxt "2"
-msgid "nd"
+msgctxt "1 (male)"
+msgid "st"
 msgstr "ий"
 
 #: src/humanize/number.py:59
-msgctxt "3"
+msgctxt "2 (male)"
+msgid "nd"
+msgstr "ий"
+
+#: src/humanize/number.py:60
+msgctxt "3 (male)"
 msgid "rd"
 msgstr "ій"
 
-#: src/humanize/number.py:60
-msgctxt "4"
-msgid "th"
-msgstr "ий"
-
 #: src/humanize/number.py:61
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "ий"
 
 #: src/humanize/number.py:62
-msgctxt "6"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "ий"
 
 #: src/humanize/number.py:63
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
 msgstr "ий"
 
 #: src/humanize/number.py:64
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
 msgstr "ий"
 
 #: src/humanize/number.py:65
-msgctxt "9"
+msgctxt "8 (male)"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
+msgid "th"
+msgstr "ий"
+
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "ий"
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "ий"
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "ий"
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "ій"
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "ий"
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "ий"
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "ий"
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "ий"
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "ий"
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "ий"
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "мільйонів"
 msgstr[1] "мільйонів"
 msgstr[2] "мільйонів"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "мільярдів"
 msgstr[1] "мільярдів"
 msgstr[2] "мільярдів"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "трильйонів"
 msgstr[1] "трильйонів"
 msgstr[2] "трильйонів"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "квадрильйонів"
 msgstr[1] "квадрильйонів"
 msgstr[2] "квадрильйонів"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "квинтиліонів"
 msgstr[1] "квинтиліонів"
 msgstr[2] "квинтиліонів"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "сикстильйонів"
 msgstr[1] "сикстильйонів"
 msgstr[2] "сикстильйонів"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "септильйонів"
 msgstr[1] "септильйонів"
 msgstr[2] "септильйонів"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "октильйонів"
 msgstr[1] "октильйонів"
 msgstr[2] "октильйонів"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "нонильйонів"
 msgstr[1] "нонильйонів"
 msgstr[2] "нонильйонів"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "децильйонів"
 msgstr[1] "децильйонів"
 msgstr[2] "децильйонів"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "гугола"
 msgstr[1] "гугола"
 msgstr[2] "гугола"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr "нуль"
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "один"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "два"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "три"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "чотири"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "п'ять"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "шість"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "сім"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "вісім"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "дев'ять"
 

--- a/src/humanize/locale/vi_VI/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/vi_VI/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2017-05-30 11:51+0700\n"
 "Last-Translator: Olivier Cortès <oc@1flow.io>\n"
 "Language-Team: vi_VI <sapd@vccloud.vn>\n"
@@ -19,172 +19,222 @@ msgstr ""
 "Generated-By: Babel 0.9.6\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
-#: src/humanize/number.py:56
-msgctxt "0"
-msgid "th"
-msgstr "."
-
 #: src/humanize/number.py:57
-msgctxt "1"
-msgid "st"
+msgctxt "0 (male)"
+msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:58
-msgctxt "2"
-msgid "nd"
+msgctxt "1 (male)"
+msgid "st"
 msgstr "."
 
 #: src/humanize/number.py:59
-msgctxt "3"
-msgid "rd"
+msgctxt "2 (male)"
+msgid "nd"
 msgstr "."
 
 #: src/humanize/number.py:60
-msgctxt "4"
-msgid "th"
+msgctxt "3 (male)"
+msgid "rd"
 msgstr "."
 
 #: src/humanize/number.py:61
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:62
-msgctxt "6"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:63
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:64
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
 msgstr "."
 
 #: src/humanize/number.py:65
-msgctxt "9"
+msgctxt "8 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "."
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "."
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "."
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "%(value)s triệu"
 msgstr[1] "%(value)s triệu"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "tỷ"
 msgstr[1] "tỷ"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "%(value)s nghìn tỷ"
 msgstr[1] "%(value)s nghìn tỷ"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "%(value)s triệu tỷ"
 msgstr[1] "%(value)s triệu tỷ"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 #, fuzzy
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "%(value)s quintillion"
 msgstr[1] "%(value)s quintillion"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 #, fuzzy
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "%(value)s sextillion"
 msgstr[1] "%(value)s sextillion"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 #, fuzzy
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "%(value)s septillion"
 msgstr[1] "%(value)s septillion"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 #, fuzzy
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "%(value)s octillion"
 msgstr[1] "%(value)s octillion"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 #, fuzzy
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "%(value)s nonillion"
 msgstr[1] "%(value)s nonillion"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 #, fuzzy
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "%(value)s décillion"
 msgstr[1] "%(value)s décillion"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 #, fuzzy
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "%(value)s gogol"
 msgstr[1] "%(value)s gogol"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr ""
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "một"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "hai"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "ba"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "bốn"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "năm"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "sáu"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "bảy"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "tám"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "chín"
 

--- a/src/humanize/locale/zh_CN/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/zh_CN/LC_MESSAGES/humanize.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 22:34+0200\n"
+"POT-Creation-Date: 2021-05-04 23:15+0200\n"
 "PO-Revision-Date: 2016-11-14 23:02+0000\n"
 "Last-Translator: Liwen SUN <sunliwen@gmail.com>\n"
 "Language-Team: Chinese (simplified)\n"
@@ -18,165 +18,215 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/humanize/number.py:56
-msgctxt "0"
-msgid "th"
-msgstr "第"
-
 #: src/humanize/number.py:57
-msgctxt "1"
-msgid "st"
+msgctxt "0 (male)"
+msgid "th"
 msgstr "第"
 
 #: src/humanize/number.py:58
-msgctxt "2"
-msgid "nd"
+msgctxt "1 (male)"
+msgid "st"
 msgstr "第"
 
 #: src/humanize/number.py:59
-msgctxt "3"
-msgid "rd"
+msgctxt "2 (male)"
+msgid "nd"
 msgstr "第"
 
 #: src/humanize/number.py:60
-msgctxt "4"
-msgid "th"
+msgctxt "3 (male)"
+msgid "rd"
 msgstr "第"
 
 #: src/humanize/number.py:61
-msgctxt "5"
+msgctxt "4 (male)"
 msgid "th"
 msgstr "第"
 
 #: src/humanize/number.py:62
-msgctxt "6"
+msgctxt "5 (male)"
 msgid "th"
 msgstr "第"
 
 #: src/humanize/number.py:63
-msgctxt "7"
+msgctxt "6 (male)"
 msgid "th"
 msgstr "第"
 
 #: src/humanize/number.py:64
-msgctxt "8"
+msgctxt "7 (male)"
 msgid "th"
 msgstr "第"
 
 #: src/humanize/number.py:65
-msgctxt "9"
+msgctxt "8 (male)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:126
+#: src/humanize/number.py:66
+msgctxt "9 (male)"
+msgid "th"
+msgstr "第"
+
+#: src/humanize/number.py:70
+msgctxt "0 (female)"
+msgid "th"
+msgstr "第"
+
+#: src/humanize/number.py:71
+msgctxt "1 (female)"
+msgid "st"
+msgstr "第"
+
+#: src/humanize/number.py:72
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "第"
+
+#: src/humanize/number.py:73
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "第"
+
+#: src/humanize/number.py:74
+msgctxt "4 (female)"
+msgid "th"
+msgstr "第"
+
+#: src/humanize/number.py:75
+msgctxt "5 (female)"
+msgid "th"
+msgstr "第"
+
+#: src/humanize/number.py:76
+msgctxt "6 (female)"
+msgid "th"
+msgstr "第"
+
+#: src/humanize/number.py:77
+msgctxt "7 (female)"
+msgid "th"
+msgstr "第"
+
+#: src/humanize/number.py:78
+msgctxt "8 (female)"
+msgid "th"
+msgstr "第"
+
+#: src/humanize/number.py:79
+msgctxt "9 (female)"
+msgid "th"
+msgstr "第"
+
+#: src/humanize/number.py:140
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:127
+#: src/humanize/number.py:141
 msgid "million"
 msgid_plural "million"
 msgstr[0] "百万"
 msgstr[1] "百万"
 
-#: src/humanize/number.py:128
+#: src/humanize/number.py:142
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "十亿"
 msgstr[1] "十亿"
 
-#: src/humanize/number.py:129
+#: src/humanize/number.py:143
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "兆"
 msgstr[1] "兆"
 
-#: src/humanize/number.py:130
+#: src/humanize/number.py:144
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "万亿"
 msgstr[1] "万亿"
 
-#: src/humanize/number.py:131
+#: src/humanize/number.py:145
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "百京"
 msgstr[1] "百京"
 
-#: src/humanize/number.py:132
+#: src/humanize/number.py:146
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "十垓"
 msgstr[1] "十垓"
 
-#: src/humanize/number.py:133
+#: src/humanize/number.py:147
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "秭"
 msgstr[1] "秭"
 
-#: src/humanize/number.py:134
+#: src/humanize/number.py:148
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "千秭"
 msgstr[1] "千秭"
 
-#: src/humanize/number.py:135
+#: src/humanize/number.py:149
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "百穰"
 msgstr[1] "百穰"
 
-#: src/humanize/number.py:136
+#: src/humanize/number.py:150
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "十沟"
 msgstr[1] "十沟"
 
-#: src/humanize/number.py:137
+#: src/humanize/number.py:151
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "古高尔"
 msgstr[1] "古高尔"
 
-#: src/humanize/number.py:228
+#: src/humanize/number.py:246
 msgid "zero"
 msgstr ""
 
-#: src/humanize/number.py:229
+#: src/humanize/number.py:247
 msgid "one"
 msgstr "一"
 
-#: src/humanize/number.py:230
+#: src/humanize/number.py:248
 msgid "two"
 msgstr "二"
 
-#: src/humanize/number.py:231
+#: src/humanize/number.py:249
 msgid "three"
 msgstr "三"
 
-#: src/humanize/number.py:232
+#: src/humanize/number.py:250
 msgid "four"
 msgstr "四"
 
-#: src/humanize/number.py:233
+#: src/humanize/number.py:251
 msgid "five"
 msgstr "五"
 
-#: src/humanize/number.py:234
+#: src/humanize/number.py:252
 msgid "six"
 msgstr "六"
 
-#: src/humanize/number.py:235
+#: src/humanize/number.py:253
 msgid "seven"
 msgstr "七"
 
-#: src/humanize/number.py:236
+#: src/humanize/number.py:254
 msgid "eight"
 msgstr "八"
 
-#: src/humanize/number.py:237
+#: src/humanize/number.py:255
 msgid "nine"
 msgstr "九"
 

--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -13,7 +13,7 @@ from .i18n import pgettext as P_
 from .i18n import thousands_separator
 
 
-def ordinal(value):
+def ordinal(value, gender="male"):
     """Converts an integer to its ordinal as a string.
 
     For example, 1 is "1st", 2 is "2nd", 3 is "3rd", etc. Works for any integer or
@@ -44,6 +44,7 @@ def ordinal(value):
         ```
     Args:
         value (int, str, float): Integer to convert.
+        gender (str): Gender for translations. Accepts either "male" or "female".
 
     Returns:
         str: Ordinal string.
@@ -52,18 +53,32 @@ def ordinal(value):
         value = int(value)
     except (TypeError, ValueError):
         return value
-    t = (
-        P_("0", "th"),
-        P_("1", "st"),
-        P_("2", "nd"),
-        P_("3", "rd"),
-        P_("4", "th"),
-        P_("5", "th"),
-        P_("6", "th"),
-        P_("7", "th"),
-        P_("8", "th"),
-        P_("9", "th"),
-    )
+    if gender == "male":
+        t = (
+            P_("0 (male)", "th"),
+            P_("1 (male)", "st"),
+            P_("2 (male)", "nd"),
+            P_("3 (male)", "rd"),
+            P_("4 (male)", "th"),
+            P_("5 (male)", "th"),
+            P_("6 (male)", "th"),
+            P_("7 (male)", "th"),
+            P_("8 (male)", "th"),
+            P_("9 (male)", "th"),
+        )
+    else:
+        t = (
+            P_("0 (female)", "th"),
+            P_("1 (female)", "st"),
+            P_("2 (female)", "nd"),
+            P_("3 (female)", "rd"),
+            P_("4 (female)", "th"),
+            P_("5 (female)", "th"),
+            P_("6 (female)", "th"),
+            P_("7 (female)", "th"),
+            P_("8 (female)", "th"),
+            P_("9 (female)", "th"),
+        )
     if value % 100 in (11, 12, 13):  # special case
         return f"{value}{t[0]}"
     return f"{value}{t[value % 10]}"

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -69,6 +69,29 @@ def test_intword_plurals(locale, number, expected_result):
         humanize.i18n.deactivate()
 
 
+@pytest.mark.parametrize(
+    ("locale", "number", "gender", "expected_result"),
+    (
+        ("fr_FR", 1, "male", "1er"),
+        ("fr_FR", 1, "female", "1ère"),
+        ("fr_FR", 2, "male", "2e"),
+        ("es_ES", 1, "male", "1º"),
+        ("es_ES", 5, "female", "5ª"),
+        ("it_IT", 3, "male", "3º"),
+        ("it_IT", 8, "female", "8ª"),
+    ),
+)
+def test_ordinal_genders(locale, number, gender, expected_result):
+    try:
+        humanize.i18n.activate(locale)
+    except FileNotFoundError:
+        pytest.skip("Generate .mo with scripts/generate-translation-binaries.sh")
+    else:
+        assert humanize.ordinal(number, gender=gender) == expected_result
+    finally:
+        humanize.i18n.deactivate()
+
+
 def test_default_locale_path_defined__file__():
     i18n = importlib.import_module("humanize.i18n")
     assert i18n._get_default_locale_path() is not None


### PR DESCRIPTION
Closes #203

Changes proposed in this pull request:

* Add `gender` argument for `humanize.ordinal`
* Rebuild locales to support ordinals by gender using message contexts
* Adds proper translations for `es_ES`, `fr_FR`, `it_IT`, `pt_BR` and `pt_PT`. For the other languages these translations have been left as it is, so this change will not break previous translations.