### PR TITLE
Update release checklist so translation binaries aren't forgotten

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,11 +12,7 @@ cd /tmp
 rm -rf humanize
 git clone https://github.com/jmoiron/humanize
 cd humanize
-```
-
-* [ ] Generate translation binaries:
-
-```bash
+# Generate translation binaries
 scripts/generate-translation-binaries.sh
 ```
 


### PR DESCRIPTION
For https://github.com/jmoiron/humanize/issues/211.

Changes proposed in this pull request:

* The 3.7.0 release didn't include translation binaries because I missed a step in the release checklist
* Let's include the step in the previous chunk to prevent this
* Longer term solution is to automate deploys, for that I will need admin permissions for this repo
