### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,4 @@ repos:
     rev: v1.17.0
     hooks:
     -   id: setup-cfg-fmt
+        args: ["--max-py-version=3.10"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Text Processing

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{py3, 39, 38, 37, 36}
+    py{py3, 310, 39, 38, 37, 36}
 
 [testenv]
 passenv =


### PR DESCRIPTION
Python 3.10 release candidate is out, and `3.10-dev` has been tested for some time, so let's declare support.

Changes proposed in this pull request:

* Add Trove classifier
* Update `tox.ini`

