### PR TITLE
Expose public functions from the root package

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,3 +1,11 @@
 # Internationalisation
 
 ::: humanize.i18n
+    selection:
+      members: [
+          "activate",
+          "deactivate",
+          "gettext",
+          "ngettext",
+          "thousands_separator"
+      ]

--- a/src/humanize/__init__.py
+++ b/src/humanize/__init__.py
@@ -2,7 +2,7 @@
 import pkg_resources
 
 from humanize.filesize import naturalsize
-from humanize.i18n import activate, deactivate, thousands_separator
+from humanize.i18n import activate, deactivate, gettext, ngettext, thousands_separator
 from humanize.number import (
     apnumber,
     clamp,
@@ -35,6 +35,7 @@ __all__ = [
     "date_and_delta",
     "deactivate",
     "fractional",
+    "gettext",
     "intcomma",
     "intword",
     "naturaldate",
@@ -42,6 +43,7 @@ __all__ = [
     "naturaldelta",
     "naturalsize",
     "naturaltime",
+    "ngettext",
     "ordinal",
     "precisedelta",
     "scientific",

--- a/src/humanize/__init__.py
+++ b/src/humanize/__init__.py
@@ -13,6 +13,9 @@ from humanize.number import (
     scientific,
 )
 from humanize.time import (
+    Unit,
+    abs_timedelta,
+    date_and_delta,
     naturaldate,
     naturalday,
     naturaldelta,
@@ -25,9 +28,11 @@ __version__ = VERSION = pkg_resources.get_distribution(__name__).version
 
 __all__ = [
     "__version__",
+    "abs_timedelta",
     "activate",
     "apnumber",
     "clamp",
+    "date_and_delta",
     "deactivate",
     "fractional",
     "intcomma",
@@ -41,5 +46,6 @@ __all__ = [
     "precisedelta",
     "scientific",
     "thousands_separator",
+    "Unit",
     "VERSION",
 ]

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -14,11 +14,14 @@ from .i18n import gettext as _
 from .i18n import ngettext
 
 __all__ = [
+    "abs_timedelta",
+    "date_and_delta",
     "naturaldelta",
     "naturaltime",
     "naturalday",
     "naturaldate",
     "precisedelta",
+    "Unit",
 ]
 
 


### PR DESCRIPTION
These functions (and the enum) are listed on the documentation but are not available from the root `humanize` package.

This change makes the public functions and enum available. There are some private functions in the `i18n` module that should probably be private; since renaming them would be a breaking change, we explicitly hide them from the documentation.

This fixes #225.