### PR TITLE
Use importlib.metadata to get package version instead of pkg_resources.get_distribution to decrease memory consumption

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ project_urls =
 packages = find:
 install_requires =
     setuptools
+    importlib-metadata;python_version < '3.8'
 python_requires = >=3.6
 include_package_data = True
 package_dir = =src

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,7 @@
 from setuptools import setup
 
-setup()
+setup(
+    install_requires=[
+        "importlib-metadata; python_version < '3.8'",
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,3 @@
 from setuptools import setup
 
-setup(
-    install_requires=[
-        "importlib-metadata; python_version < '3.8'",
-    ],
-)
+setup()

--- a/src/humanize/__init__.py
+++ b/src/humanize/__init__.py
@@ -1,5 +1,5 @@
 """Main package for humanize."""
-import pkg_resources
+import sys
 
 from humanize.filesize import naturalsize
 from humanize.i18n import activate, deactivate, thousands_separator
@@ -20,7 +20,12 @@ from humanize.time import (
     precisedelta,
 )
 
-__version__ = VERSION = pkg_resources.get_distribution(__name__).version
+if sys.version_info >= (3, 8, 0):
+    from importlib.metadata import version
+    __version__ = version(__name__)
+else:
+    import pkg_resources
+    __version__ = VERSION = pkg_resources.get_distribution(__name__).version
 
 
 __all__ = [

--- a/src/humanize/__init__.py
+++ b/src/humanize/__init__.py
@@ -1,5 +1,4 @@
 """Main package for humanize."""
-import sys
 
 from humanize.filesize import naturalsize
 from humanize.i18n import activate, deactivate, thousands_separator
@@ -20,12 +19,14 @@ from humanize.time import (
     precisedelta,
 )
 
-if sys.version_info >= (3, 8, 0):
-    from importlib.metadata import version
-    __version__ = version(__name__)
-else:
-    import pkg_resources
-    __version__ = VERSION = pkg_resources.get_distribution(__name__).version
+try:
+    # Python 3.8+
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # <Python 3.7 and lower
+    import importlib_metadata
+
+__version__ = importlib_metadata.version(__name__)
 
 
 __all__ = [


### PR DESCRIPTION
pkg_resources use a lot of memory and after introducing importlib.metadata in 3.8 looks obsolete. So let's change way to get package version and get rid of pkg_resources import.