### PR TITLE
Update github CI test with python 3.10 for new release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3", "3.6", "3.7", "3.8", "3.9", "3.10-dev"]
+        python-version: ["pypy3", "3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           # Include new variables for Codecov


### PR DESCRIPTION
Fixes #
Added python 3.10 to test yml for github CI
Changes proposed in this pull request:

* Updated to 3.10 instead of 3.10-dev

