### PR TITLE
Remove redundant setuptools from install_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    setuptools
     importlib-metadata;python_version < '3.8'
 python_requires = >=3.6
 include_package_data = True


### PR DESCRIPTION
The `setuptools` install requires was added as of commit a3e0fd8cdfe7246f0c443e00c89e4579b33ab254 for `pkg_resources`.
But after #227 was merged, `pkg_resources` isn't used at all, so as a result `setuptools` can be removed from install requires.