### PR TITLE
Specify pypy-3.8 on GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["pypy-3.8", "3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           # Include new variables for Codecov


### PR DESCRIPTION
Changes proposed in this pull request:

* `pypy3` has started failing for macOS on GHA (https://github.com/jmoiron/humanize/pull/235#issuecomment-958846008):

```
Run actions/setup-python@v2
Error: PyPy 3.6 not found
```

* `pypy3` isn't explicitly documented at https://github.com/actions/setup-python#specifying-a-pypy-version
* Let's explicitly test the latest `pypy-3.8`. We could test `pypy-3.6` and `pypy-3.7` but 3.6 is EOL next month and testing a single PyPy should be enough.
