### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,26 +1,20 @@
 name: Docs
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: docs-${{ hashFiles('**/tox.ini') }}
-          restore-keys: |
-            docs-
-
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: "3.x"
+          pip: cache
+          pip-dependency-path: tox.ini
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -5,8 +5,10 @@ on:
       - master
     paths:
       - .github/labels.yml
+  workflow_dispatch:
+
 jobs:
-  build:
+  sync:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,12 @@
 name: Lint
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.2
+      - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,10 +5,11 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   update_release_draft:
-    if: github.repository == 'jmoiron/humanize'
+    if: github.repository_owner == 'jmoiron'
     runs-on: ubuntu-latest
     steps:
       # Drafts your next release notes as pull requests are merged into "master"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.8", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           # Include new variables for Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,12 @@
 name: Test
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   FORCE_COLOR: 1
 
 jobs:
-  build:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -26,21 +26,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-v1-${{
-            hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-v1-
+          cache: pip
+          cache-dependency-path: setup.cfg
 
       - name: Install Linux dependencies
         if: startsWith(matrix.os, 'ubuntu')
@@ -67,7 +54,7 @@ jobs:
           tox -e py
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           flags: ${{ matrix.codecov-flag }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,20 @@ repos:
     hooks:
       - id: isort
 
+  - repo: https://github.com/myint/autoflake
+    rev: v1.4
+    hooks:
+      - id: autoflake
+        name: autoflake
+        args:
+          [
+            "--in-place",
+            "--remove-unused-variables",
+            "--remove-all-unused-imports",
+          ]
+        language: python
+        files: \.py$
+
   - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: isort
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:
       - id: flake8
@@ -50,4 +50,7 @@ repos:
   - repo: https://github.com/asottile/setup-cfg-fmt
     rev: v1.18.0
     hooks:
-    -   id: setup-cfg-fmt
+      - id: setup-cfg-fmt
+
+ci:
+  autoupdate_schedule: quarterly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
+    rev: v2.31.0
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
 
   - repo: https://github.com/psf/black
-    rev: 21.11b1
+    rev: 22.1.0
     hooks:
       - id: black
         args: [--target-version=py37]
@@ -42,7 +42,7 @@ repos:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
       - id: check-merge-conflict
       - id: check-toml
@@ -57,7 +57,7 @@ repos:
         files: "src/"
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 0.5.1
+    rev: 0.5.2
     hooks:
       - id: tox-ini-fmt
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,23 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.0
+    rev: v2.29.1
     hooks:
       - id: pyupgrade
-        args: ["--py36-plus"]
+        args: [--py37-plus]
 
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 21.11b1
     hooks:
       - id: black
-        args: ["--target-version", "py36"]
+        args: [--target-version=py37]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
+    rev: 5.10.1
     hooks:
       - id: isort
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
@@ -48,7 +48,7 @@ repos:
       - id: tox-ini-fmt
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.18.0
+    rev: v1.20.0
     hooks:
       - id: setup-cfg-fmt
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target_version = ["py36"]
+target_version = ["py37"]
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -38,7 +37,7 @@ project_urls =
 packages = find:
 install_requires =
     importlib-metadata;python_version < '3.8'
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 package_dir = =src
 zip_safe = False

--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -129,14 +129,14 @@ def intcomma(value, ndigits=None):
     else:
         orig = str(value)
 
-    new = re.sub(r"^(-?\d+)(\d{3})", fr"\g<1>{sep}\g<2>", orig)
+    new = re.sub(r"^(-?\d+)(\d{3})", rf"\g<1>{sep}\g<2>", orig)
     if orig == new:
         return new
     else:
         return intcomma(new)
 
 
-powers = [10 ** x for x in (3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 100)]
+powers = [10**x for x in (3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 100)]
 human_powers = (
     NS_("thousand", "thousand"),
     NS_("million", "million"),
@@ -197,7 +197,7 @@ def intword(value, format="%.1f"):
     for ordinal, power in enumerate(powers[1:], 1):
         if value < power:
             chopped = value / float(powers[ordinal - 1])
-            if float(format % chopped) == float(10 ** 3):
+            if float(format % chopped) == float(10**3):
                 chopped = value / float(powers[ordinal])
                 singular, plural = human_powers[ordinal]
                 return (

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -7,7 +7,6 @@ These are largely borrowed from Django's `contrib.humanize`.
 
 import datetime as dt
 import math
-import warnings
 from enum import Enum
 from functools import total_ordering
 

--- a/tests/test_filesize.py
+++ b/tests/test_filesize.py
@@ -22,14 +22,14 @@ import humanize
         ([3000, False, True], "2.9K"),
         ([3000000, False, True], "2.9M"),
         ([1024, False, True], "1.0K"),
-        ([10 ** 26 * 30, False, True], "2481.5Y"),
-        ([10 ** 26 * 30, True], "2481.5 YiB"),
-        ([10 ** 26 * 30], "3000.0 YB"),
+        ([10**26 * 30, False, True], "2481.5Y"),
+        ([10**26 * 30, True], "2481.5 YiB"),
+        ([10**26 * 30], "3000.0 YB"),
         ([1, False, False], "1 Byte"),
         ([3141592, False, False, "%.2f"], "3.14 MB"),
         ([3000, False, True, "%.3f"], "2.930K"),
         ([3000000000, False, True, "%.0f"], "3G"),
-        ([10 ** 26 * 30, True, False, "%.3f"], "2481.542 YiB"),
+        ([10**26 * 30, True, False, "%.3f"], "2481.542 YiB"),
     ],
 )
 def test_naturalsize(test_args, expected):

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -89,7 +89,7 @@ def test_intword_powers():
         (["8100000000000000000000000000000000"], "8.1 decillion"),
         ([None], None),
         (["1230000", "%0.2f"], "1.23 million"),
-        ([10 ** 101], "1" + "0" * 101),
+        ([10**101], "1" + "0" * 101),
     ],
 )
 def test_intword(test_args, expected):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{py3, 310, 39, 38, 37, 36}
+    py{py3, 310, 39, 38, 37}
 
 [testenv]
 passenv =


### PR DESCRIPTION
Python 3.6 is (almost) EOL:

| cycle | latest |  release   |    eol     |
|:------|:-------|:----------:|:----------:|
| 3.10  | 3.10.0 | 2021-10-04 | 2026-10-04 |
| 3.9   | 3.9.9  | 2020-10-05 | 2025-10-05 |
| 3.8   | 3.8.12 | 2019-10-14 | 2024-10-14 |
| 3.7   | 3.7.12 | 2018-06-27 | 2023-06-27 |
| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |

Also update some other CI config like using actions/setup-python's own pip caching instead of using actions/cache directly.

# TODO

* [x] Hopefully we can release the https://github.com/jmoiron/humanize/pull/234 deprecations first 
* [x] and also include their removals in this major version bump: https://github.com/jmoiron/humanize/pull/241
* [x] Merge https://github.com/jmoiron/humanize/pull/253 first
* [ ] After release, update https://github.com/conda-forge/humanize-feedstock/blob/master/recipe/meta.yaml