### PR TITLE
Reinstate `VERSION` and deprecate

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 [![Tidelift](https://tidelift.com/badges/package/pypi/humanize)](https://tidelift.com/subscription/pkg/pypi-humanize?utm_source=pypi-humanize&utm_medium=badge)
 
 This modest package contains various common humanization utilities, like turning
-a number into a fuzzy human readable duration ("3 minutes ago") or into a human
-readable size or throughput. It is localized to:
+a number into a fuzzy human-readable duration ("3 minutes ago") or into a
+human-readable size or throughput. It is localized to:
 
 * Bengali
 * Brazilian Portuguese

--- a/src/humanize/__init__.py
+++ b/src/humanize/__init__.py
@@ -1,5 +1,8 @@
 """Main package for humanize."""
 
+import sys
+import warnings
+
 from humanize.filesize import naturalsize
 from humanize.i18n import activate, deactivate, thousands_separator
 from humanize.number import (
@@ -27,6 +30,25 @@ except ImportError:
     import importlib_metadata
 
 __version__ = importlib_metadata.version(__name__)
+
+
+if sys.version_info >= (3, 7):
+    # This technique isn't available for 3.6 but we don't need to warn for 3.6
+    # because we'll drop 3.6 at the same time as removing this
+    def __getattr__(name):
+        if name == "VERSION":
+            warnings.warn(
+                "VERSION is deprecated and will be removed in humanize 4.0. "
+                "Use __version__ instead, available since humanize 1.0 (Feb 2020).",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return __version__
+        raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+else:
+    VERSION = __version__
 
 
 __all__ = [

--- a/tests/test_humanize.py
+++ b/tests/test_humanize.py
@@ -1,0 +1,16 @@
+"""Other tests."""
+import sys
+
+import pytest
+
+import humanize
+
+
+def test_version():
+    if sys.version_info >= (3, 7):
+        with pytest.warns(DeprecationWarning):
+            VERSION = humanize.VERSION
+    else:
+        VERSION = humanize.VERSION
+
+    assert VERSION == humanize.__version__

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,3 +1,4 @@
+"""Internationalisation tests."""
 import datetime as dt
 import importlib
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """Number tests."""
 
 import pytest

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """Tests for time humanizing."""
 
 import datetime as dt

--- a/tox.ini
+++ b/tox.ini
@@ -26,4 +26,4 @@ commands =
     pre-commit run --all-files --show-diff-on-failure
 
 [pytest]
-addopts = --doctest-modules
+addopts = --color=yes --doctest-modules


### PR DESCRIPTION
Changes proposed in this pull request:

* `VERSION` was inadvertently removed in https://github.com/jmoiron/humanize/pull/227 but not yet released
* Let's reinstate it
* But as it's non-standard and we've had the standard `__version__` since humanize 1.0 (Feb 2020), let's deprecate it and remove it in the next major bump
* We can use the technique for deprecating constants only available in Python 3.7+, which is fine as the next major bump will also drop 3.6 (https://github.com/jmoiron/humanize/pull/239)
