### PR TITLE
Remove deprecated private function aliases

### DIFF
--- a/src/humanize/i18n.py
+++ b/src/humanize/i18n.py
@@ -1,10 +1,9 @@
 """Activate, get and deactivate translations."""
 import gettext as gettext_module
 import os.path
-import warnings
 from threading import local
 
-__all__ = ["activate", "deactivate", "gettext", "ngettext", "thousands_separator"]
+__all__ = ["activate", "deactivate", "thousands_separator"]
 
 _TRANSLATIONS = {None: gettext_module.NullTranslations()}
 _CURRENT = local()
@@ -79,26 +78,6 @@ def _gettext(message):
     return get_translation().gettext(message)
 
 
-def gettext(message):
-    """Get translation.
-
-    Args:
-        message (str): Text to translate.
-
-    Returns:
-        str: Translated text.
-
-    WARNING: This function has been deprecated. It is still available as the private
-    member `_gettext`.
-    """
-    warnings.warn(
-        "`gettext` has been deprecated. "
-        "It is still available as the private member `_gettext`.",
-        DeprecationWarning,
-    )
-    return _gettext(message)
-
-
 def _pgettext(msgctxt, message):
     """Fetches a particular translation.
 
@@ -124,30 +103,6 @@ def _pgettext(msgctxt, message):
         return message if translation == key else translation
 
 
-def pgettext(msgctxt, message):
-    """Fetches a particular translation.
-
-    It works with `msgctxt` .po modifiers and allows duplicate keys with different
-    translations.
-
-    Args:
-        msgctxt (str): Context of the translation.
-        message (str): Text to translate.
-
-    Returns:
-        str: Translated text.
-
-    WARNING: This function has been deprecated. It is still available as the private
-    member `_pgettext`.
-    """
-    warnings.warn(
-        "`pgettext` has been deprecated. "
-        "It is still available as the private member `_pgettext`.",
-        DeprecationWarning,
-    )
-    return _pgettext(msgctxt, message)
-
-
 def _ngettext(message, plural, num):
     """Plural version of _gettext.
 
@@ -161,29 +116,6 @@ def _ngettext(message, plural, num):
         str: Translated text.
     """
     return get_translation().ngettext(message, plural, num)
-
-
-def ngettext(msgctxt, message):
-    """Plural version of gettext.
-
-    Args:
-        message (str): Singular text to translate.
-        plural (str): Plural text to translate.
-        num (str): The number (e.g. item count) to determine translation for the
-            respective grammatical number.
-
-    Returns:
-        str: Translated text.
-
-    WARNING: This function has been deprecated. It is still available as the private
-    member `_ngettext`.
-    """
-    warnings.warn(
-        "`ngettext` has been deprecated. "
-        "It is still available as the private member `_ngettext`.",
-        DeprecationWarning,
-    )
-    return _ngettext(msgctxt, message)
 
 
 def _gettext_noop(message):
@@ -205,33 +137,6 @@ def _gettext_noop(message):
     return message
 
 
-def gettext_noop(message):
-    """Mark a string as a translation string without translating it.
-
-    Example usage:
-    ```python
-    CONSTANTS = [_gettext_noop('first'), _gettext_noop('second')]
-    def num_name(n):
-        return _gettext(CONSTANTS[n])
-    ```
-
-    Args:
-        message (str): Text to translate in the future.
-
-    Returns:
-        str: Original text, unchanged.
-
-    WARNING: This function has been deprecated. It is still available as the private
-    member `_gettext_noop`.
-    """
-    warnings.warn(
-        "`gettext_noop` has been deprecated. "
-        "It is still available as the private member `_gettext_noop`.",
-        DeprecationWarning,
-    )
-    return _gettext_noop(message)
-
-
 def _ngettext_noop(singular, plural):
     """Mark two strings as pluralized translations without translating them.
 
@@ -250,34 +155,6 @@ def _ngettext_noop(singular, plural):
         tuple: Original text, unchanged.
     """
     return (singular, plural)
-
-
-def ngettext_noop(singular, plural):
-    """Mark two strings as pluralized translations without translating them.
-
-    Example usage:
-    ```python
-    CONSTANTS = [ngettext_noop('first', 'firsts'), ngettext_noop('second', 'seconds')]
-    def num_name(n):
-        return _ngettext(*CONSTANTS[n])
-    ```
-
-    Args:
-        singular (str): Singular text to translate in the future.
-        plural (str): Plural text to translate in the future.
-
-    Returns:
-        tuple: Original text, unchanged.
-
-    WARNING: This function has been deprecated. It is still available as the private
-    member `_ngettext_noop`.
-    """
-    warnings.warn(
-        "`ngettext_noop` has been deprecated. "
-        "It is still available as the private member `_ngettext_noop`.",
-        DeprecationWarning,
-    )
-    return _ngettext_noop(singular, plural)
 
 
 def thousands_separator() -> str:

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -7,8 +7,7 @@ These are largely borrowed from Django's `contrib.humanize`.
 
 import datetime as dt
 import math
-import warnings
-from enum import Enum, EnumMeta
+from enum import Enum
 from functools import total_ordering
 
 from .i18n import _gettext as _
@@ -40,43 +39,6 @@ class _Unit(Enum):
         return NotImplemented
 
 
-class _UnitMeta(EnumMeta):
-    """Metaclass for an enum that emits deprecation warnings when accessed."""
-
-    def __getattribute__(self, name):
-        warnings.warn(
-            "`Unit` has been deprecated. "
-            "The enum is still available as the private member `_Unit`.",
-            DeprecationWarning,
-        )
-        return EnumMeta.__getattribute__(_Unit, name)
-
-    def __getitem__(cls, name):
-        warnings.warn(
-            "`Unit` has been deprecated. "
-            "The enum is still available as the private member `_Unit`.",
-            DeprecationWarning,
-        )
-        return _Unit.__getitem__(name)
-
-    def __call__(
-        cls, value, names=None, *, module=None, qualname=None, type=None, start=1
-    ):
-        warnings.warn(
-            "`Unit` has been deprecated. "
-            "The enum is still available as the private member `_Unit`.",
-            DeprecationWarning,
-        )
-        return _Unit.__call__(
-            value, names, module=module, qualname=qualname, type=type, start=start
-        )
-
-
-class Unit(Enum, metaclass=_UnitMeta):
-    # Temporary alias for _Unit to allow backwards-compatible usage.
-    pass
-
-
 def _now():
     return dt.datetime.now()
 
@@ -94,26 +56,6 @@ def _abs_timedelta(delta):
         now = _now()
         return now - (now + delta)
     return delta
-
-
-def abs_timedelta(delta):
-    """Return an "absolute" value for a timedelta, always representing a time distance.
-
-    Args:
-        delta (datetime.timedelta): Input timedelta.
-
-    Returns:
-        datetime.timedelta: Absolute timedelta.
-
-    WARNING: This function has been deprecated. It is still available as the private
-    member `_abs_timedelta`.
-    """
-    warnings.warn(
-        "`abs_timedelta` has been deprecated. "
-        "It is still available as the private member `_abs_timedelta`.",
-        DeprecationWarning,
-    )
-    return _abs_timedelta(delta)
 
 
 def _date_and_delta(value, *, now=None):
@@ -137,22 +79,6 @@ def _date_and_delta(value, *, now=None):
         except (ValueError, TypeError):
             return None, value
     return date, _abs_timedelta(delta)
-
-
-def date_and_delta(delta):
-    """Turn a value into a date and a timedelta which represents how long ago it was.
-
-    If that's not possible, return `(None, value)`.
-
-    WARNING: This function has been deprecated. It is still available as the private
-    member `_date_and_delta`.
-    """
-    warnings.warn(
-        "`date_and_delta` has been deprecated. "
-        "It is still available as the private member `_date_and_delta`.",
-        DeprecationWarning,
-    )
-    return _date_and_delta(delta)
 
 
 def naturaldelta(


### PR DESCRIPTION
Removes aliases for deprecated functions introduced in #234.

This completes the deprecation of these public functions (the functions are still accessible as private members of their modules).
