### PR TITLE
Temporarily comment out to avoid warning during `import humanize`

### DIFF
--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -44,11 +44,12 @@ class _UnitMeta(EnumMeta):
     """Metaclass for an enum that emits deprecation warnings when accessed."""
 
     def __getattribute__(self, name):
-        warnings.warn(
-            "`Unit` has been deprecated. "
-            "The enum is still available as the private member `_Unit`.",
-            DeprecationWarning,
-        )
+        # Temporarily comment out to avoid warning during 'import humanize'
+        # warnings.warn(
+        #     "`Unit` has been deprecated. "
+        #     "The enum is still available as the private member `_Unit`.",
+        #     DeprecationWarning,
+        # )
         return EnumMeta.__getattribute__(_Unit, name)
 
     def __getitem__(cls, name):


### PR DESCRIPTION
Temporary fix for #242.

Changes proposed in this pull request:

* Comment out the warning to avoid warning during `import humanize`

# Before

```console
$ python3 -W error -c 'import humanize'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/humanize/__init__.py", line 17, in <module>
    from humanize.time import (
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/humanize/time.py", line 75, in <module>
    class Unit(Enum, metaclass=_UnitMeta):
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/enum.py", line 215, in __new__
    enum_class._member_names_ = []               # names in definition order
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/enum.py", line 470, in __setattr__
    member_map = cls.__dict__.get('_member_map_', {})
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/humanize/time.py", line 47, in __getattribute__
    warnings.warn(
DeprecationWarning: `Unit` has been deprecated. The enum is still available as the private member `_Unit`.
$ 
```

# After

```console
$  python3 -W error -c 'import humanize'
$ 
```