### PR TITLE
Do not issue deprecation warnings during import

### DIFF
--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -22,6 +22,8 @@ __all__ = [
     "precisedelta",
 ]
 
+_IMPORTING = True
+
 
 @total_ordering
 class _Unit(Enum):
@@ -44,30 +46,32 @@ class _UnitMeta(EnumMeta):
     """Metaclass for an enum that emits deprecation warnings when accessed."""
 
     def __getattribute__(self, name):
-        # Temporarily comment out to avoid warning during 'import humanize'
-        # warnings.warn(
-        #     "`Unit` has been deprecated. "
-        #     "The enum is still available as the private member `_Unit`.",
-        #     DeprecationWarning,
-        # )
+        if not _IMPORTING:
+            warnings.warn(
+                "`Unit` has been deprecated. "
+                "The enum is still available as the private member `_Unit`.",
+                DeprecationWarning,
+            )
         return EnumMeta.__getattribute__(_Unit, name)
 
     def __getitem__(cls, name):
-        warnings.warn(
-            "`Unit` has been deprecated. "
-            "The enum is still available as the private member `_Unit`.",
-            DeprecationWarning,
-        )
+        if not _IMPORTING:
+            warnings.warn(
+                "`Unit` has been deprecated. "
+                "The enum is still available as the private member `_Unit`.",
+                DeprecationWarning,
+            )
         return _Unit.__getitem__(name)
 
     def __call__(
         cls, value, names=None, *, module=None, qualname=None, type=None, start=1
     ):
-        warnings.warn(
-            "`Unit` has been deprecated. "
-            "The enum is still available as the private member `_Unit`.",
-            DeprecationWarning,
-        )
+        if not _IMPORTING:
+            warnings.warn(
+                "`Unit` has been deprecated. "
+                "The enum is still available as the private member `_Unit`.",
+                DeprecationWarning,
+            )
         return _Unit.__call__(
             value, names, module=module, qualname=qualname, type=type, start=start
         )
@@ -618,3 +622,5 @@ def precisedelta(value, minimum_unit="seconds", suppress=(), format="%0.2f") -> 
     tail = texts[-1]
 
     return _("%s and %s") % (head, tail)
+
+_IMPORTING = False


### PR DESCRIPTION
Prior to this change, the `Unit` enum would issue a deprecation warning
during import when its `__dict__` was accessed. This is not correct: the
warning should only be issued if the enum is actually accessed.

This change ensures that no deprecation warnings are issued by the enum
during import.

Fixes #242.

e.g:

```python
$ python -Werror
>>> from humanize import time
>>> time.Unit.DAYS
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/samuelsearles-bryant/dev/samueljsb/humanize/src/humanize/time.py", line 50, in __getattribute__
    warnings.warn(
DeprecationWarning: `Unit` has been deprecated. The enum is still available as the private member `_Unit`.
```
