### PR TITLE
Use humanize.intcomma to format years in time module

### DIFF
--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -13,6 +13,7 @@ from functools import total_ordering
 
 from .i18n import _gettext as _
 from .i18n import _ngettext
+from .number import intcomma
 
 __all__ = [
     "naturaldelta",
@@ -264,7 +265,7 @@ def naturaldelta(
         else:
             return _ngettext("1 year, %d day", "1 year, %d days", days) % days
     else:
-        return _ngettext("%d year", "%d years", years) % years
+        return _ngettext("%s year", "%s years", years) % intcomma(years)
 
 
 def naturaltime(
@@ -605,6 +606,10 @@ def precisedelta(value, minimum_unit="seconds", suppress=(), format="%0.2f") -> 
             fmt_txt = _ngettext(singular_txt, plural_txt, value)
             if unit == min_unit and math.modf(value)[0] > 0:
                 fmt_txt = fmt_txt.replace("%d", format)
+            elif unit == YEARS:
+                fmt_txt = fmt_txt.replace("%d", "%s")
+                texts.append(fmt_txt % intcomma(value))
+                continue
 
             texts.append(fmt_txt % value)
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -118,6 +118,7 @@ def test_naturaldelta_nomonths(test_input, expected):
         (dt.timedelta(days=65), "2 months"),
         (dt.timedelta(days=9), "9 days"),
         (dt.timedelta(days=365), "a year"),
+        (dt.timedelta(days=365 * 1_141), "1,141 years"),
         ("NaN", "NaN"),
     ],
 )
@@ -446,6 +447,7 @@ def test_naturaltime_minimum_unit_explicit(minimum_unit, seconds, expected):
         (3600 * 24 * 2, "seconds", "2 days"),
         (3600 * 24 * 365, "seconds", "1 year"),
         (3600 * 24 * 365 * 2, "seconds", "2 years"),
+        (3600 * 24 * 365 * 1_963, "seconds", "1,963 years"),
     ],
 )
 def test_precisedelta_one_unit_enough(val, min_unit, expected):


### PR DESCRIPTION
Related to #245

Presently, it is hard to read very long times because the largest time denomination that `humanize` includes is years. In this pull request, `humanize.intcomma()` is now used to format the number of years returned by `naturaldelta()` and `precisedelta()`.

Alternate approaches considered include:
1. Adding a `millennia` denomination, but this would require all translations to be updated.
2. Using the `{:n}` format specifier along with the standard `locale` module, but locale has inconsistent behavior across platforms and `humanize` already uses an internal localization module.