### PR TITLE
Deprecate `when` parameter of `naturaldelta`

### DIFF
--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -173,6 +173,9 @@ def naturaldelta(
         minimum_unit (str): The lowest unit that can be used.
         when (datetime.datetime): Point in time relative to which _value_ is
             interpreted.  Defaults to the current time in the local timezone.
+            .. deprecated:: 3.13
+            If you need to construct a timedelta, do it inline as the first
+            argument.
 
     Returns:
         str: A natural representation of the amount of time elapsed.
@@ -189,6 +192,14 @@ def naturaldelta(
 
         assert naturaldelta(later, when=now) == "30 minutes"
     """
+    if when:
+        warnings.warn(
+            "The `when` parameter of naturaldelta() is deprecated and will be "
+            "removed in humanize 4.0. If you need to construct a timedelta, "
+            "do it inline as the first argument.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     tmp = _Unit[minimum_unit.upper()]
     if tmp not in (_Unit.SECONDS, _Unit.MILLISECONDS, _Unit.MICROSECONDS):
         raise ValueError(f"Minimum unit '{minimum_unit}' not supported")

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -173,7 +173,7 @@ def naturaldelta(
         minimum_unit (str): The lowest unit that can be used.
         when (datetime.datetime): Point in time relative to which _value_ is
             interpreted.  Defaults to the current time in the local timezone.
-            .. deprecated:: 3.13
+            .. deprecated:: 3.14
             If you need to construct a timedelta, do it inline as the first
             argument.
 

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -194,7 +194,7 @@ def naturaldelta(
     """
     if when:
         warnings.warn(
-            "The `when` parameter of naturaldelta() is deprecated and will be "
+            "The `when` parameter of `naturaldelta()` is deprecated and will be "
             "removed in humanize 4.0. If you need to construct a timedelta, "
             "do it inline as the first argument.",
             DeprecationWarning,

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -173,9 +173,8 @@ def naturaldelta(
         minimum_unit (str): The lowest unit that can be used.
         when (datetime.datetime): Point in time relative to which _value_ is
             interpreted.  Defaults to the current time in the local timezone.
-            .. deprecated:: 3.14
-            If you need to construct a timedelta, do it inline as the first
-            argument.
+            Deprecated in version 3.14; If you need to construct a timedelta,
+            do it inline as the first argument.
 
     Returns:
         str: A natural representation of the amount of time elapsed.


### PR DESCRIPTION
Related to #247, but does not close.

Adds deprecation warnings for `naturaldelta(..., when)` because this parameter does not make sense for a time*delta*.

Didn't add test because it seems silly to test for the presence of deprecation warnings that will only be around until the next release.
