### PR TITLE
Remove `when` from `naturaldelta()` and allow largest `timedelta`

### DIFF
--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -119,7 +119,9 @@ def test_naturaldelta_nomonths(test_input, expected):
         (dt.timedelta(days=9), "9 days"),
         (dt.timedelta(days=365), "a year"),
         (dt.timedelta(days=365 * 1_141), "1,141 years"),
-        ("NaN", "NaN"),
+        ("NaN", "NaN"),  # Returns non-numbers unchanged.
+        # largest possible timedelta
+        (dt.timedelta(days=999_999_999), "2,739,726 years"),
     ],
 )
 def test_naturaldelta(test_input, expected):

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -334,37 +334,6 @@ def test_naturaldelta_minimum_unit_explicit(minimum_unit, seconds, expected):
 
 
 @pytest.mark.parametrize(
-    "test_input, when, expected",
-    [
-        (NOW, NOW, "a moment"),
-        (NOW_UTC, NOW_UTC, "a moment"),
-    ],
-)
-def test_naturaldelta_when_explicit(test_input, when, expected):
-    # Act / Assert
-    assert humanize.naturaldelta(test_input, when=when) == expected
-
-
-@pytest.mark.parametrize(
-    "value, when",
-    [
-        (NOW_UTC, None),
-        (NOW_UTC, NOW),
-        (NOW_UTC_PLUS_01_00, None),
-        (NOW_UTC_PLUS_01_00, NOW),
-    ],
-)
-def test_naturaldelta_when_missing_tzinfo(value, when):
-    """Subtraction `when - value` is not defined by the `datetime` module when
-    either operand has not timezone-info (`tz=None`) and raises a TypeError.
-    """
-
-    # Act / Assert
-    with pytest.raises(TypeError):
-        humanize.naturaldelta(value, when=when)
-
-
-@pytest.mark.parametrize(
     "seconds, expected",
     [
         (ONE_MICROSECOND, "now"),


### PR DESCRIPTION
Changes proposed in this pull request:

* Refactor naturaldelta() to remove the when parameter, deprecated in [#248](https://github.com/jmoiron/humanize/pull/248)
* Refactor naturaldelta() to no longer use _data_and_delta so that the maximum timedelta can be used
